### PR TITLE
 switch offsets to an array of uint16

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,12 +202,7 @@ fields lazily (on access).
     name                                         time/op
     DecodeSimpleAccessNone/pb-8                     177ns ± 0%
     DecodeSimpleAccessNone/gogopb-8                 102ns ± 0%
-    DecodeSimpleAccessNone/zeropb-8                69.8ns ± 1%
-
-    name                                         speed
-    DecodeSimpleAccessNone/pb-8                   610MB/s ± 1%
-    DecodeSimpleAccessNone/gogopb-8              1.05GB/s ± 2%
-    DecodeSimpleAccessNone/zeropb-8              1.55GB/s ± 1%
+    DecodeSimpleAccessNone/zeropb-8                50.4ns ± 3%
 
     name                                         allocs/op
     DecodeSimpleAccessNone/pb-8                      4.00 ± 0%
@@ -220,12 +215,7 @@ fields.
     name                                         time/op
     DecodeSimpleAccessAll/pb-8                      228ns ± 0%
     DecodeSimpleAccessAll/gogopb-8                  150ns ± 2%
-    DecodeSimpleAccessAll/zeropb-8                  162ns ± 0%
-
-    name                                         speed
-    DecodeSimpleAccessAll/pb-8                    473MB/s ± 0%
-    DecodeSimpleAccessAll/gogopb-8                717MB/s ± 2%
-    DecodeSimpleAccessAll/zeropb-8                662MB/s ± 2%
+    DecodeSimpleAccessAll/zeropb-8                  132ns ± 0%
 
     name                                         allocs/op
     DecodeSimpleAccessAll/pb-8                       4.00 ± 0%
@@ -238,12 +228,7 @@ slower than other libraries.
     name                                         time/op
     DecodeSimpleAccessRepeatedly/pb-8               347ns ± 1%
     DecodeSimpleAccessRepeatedly/gogopb-8           259ns ± 0%
-    DecodeSimpleAccessRepeatedly/zeropb-8           352ns ± 0%
-
-    name                                         speed
-    DecodeSimpleAccessRepeatedly/pb-8             311MB/s ± 0%
-    DecodeSimpleAccessRepeatedly/gogopb-8         416MB/s ± 0%
-    DecodeSimpleAccessRepeatedly/zeropb-8         306MB/s ± 0%
+    DecodeSimpleAccessRepeatedly/zeropb-8           305ns ± 1%
 
     name                                         allocs/op
     DecodeSimpleAccessRepeatedly/pb-8                4.00 ± 0%
@@ -258,14 +243,9 @@ number of top-level fields set in the message and independent of any fields in
 sub-messages.
 
     name                                         time/op
-    DecodeComplexAccessOne/pb-8                    1.66µs ± 3%
+    DecodeComplexAccessOne/pb-8                    1660ns ± 3%
     DecodeComplexAccessOne/gogopb-8                 829ns ± 2%
-    DecodeComplexAccessOne/zeropb-8                 485ns ± 2%
-
-    name                                         speed
-    DecodeComplexAccessOne/pb-8                   278MB/s ± 3%
-    DecodeComplexAccessOne/gogopb-8               533MB/s ±16%
-    DecodeComplexAccessOne/zeropb-8               948MB/s ± 2%
+    DecodeComplexAccessOne/zeropb-8                 167ns ± 0%
 
     name                                         allocs/op
     DecodeComplexAccessOne/pb-8                      33.0 ± 0%
@@ -273,17 +253,14 @@ sub-messages.
     DecodeComplexAccessOne/zeropb-8                  0.00
 
 A measurement of zeropb's unfortunate re-parsing of the message for repeated
-fields.
+fields. Note that in this case the overhead happens to be less than the benefit
+of lazily decoding one field out of a complex message, resulting in an overall
+speedup from other libraries.
 
     name                                         time/op
-    DecodeComplexAccessRepeatedMessage/pb-8        1.83µs ± 0%
-    DecodeComplexAccessRepeatedMessage/gogopb-8    1.00µs ± 1%
-    DecodeComplexAccessRepeatedMessage/zeropb-8    1.19µs ± 1%
-
-    name                                         speed
-    DecodeComplexAccessRepeatedMessage/pb-8       251MB/s ± 0%
-    DecodeComplexAccessRepeatedMessage/gogopb-8   459MB/s ± 1%
-    DecodeComplexAccessRepeatedMessage/zeropb-8   386MB/s ± 1%
+    DecodeComplexAccessRepeatedMessage/pb-8       1830ns ± 0%
+    DecodeComplexAccessRepeatedMessage/gogopb-8   1000ns ± 1%
+    DecodeComplexAccessRepeatedMessage/zeropb-8    718ns ± 1%
 
     name                                         allocs/op
     DecodeComplexAccessRepeatedMessage/pb-8          33.0 ± 0%
@@ -298,12 +275,7 @@ benchmark, zeropb would be infinitely fast :-D!
     name                                         time/op
     EncodeSimpleSetAll/pb-8                         212ns ± 0%
     EncodeSimpleSetAll/gogopb-8                     175ns ± 1%
-    EncodeSimpleSetAll/zeropb-8                     135ns ± 0%
-
-    name                                         speed
-    EncodeSimpleSetAll/pb-8                       508MB/s ± 0%
-    EncodeSimpleSetAll/gogopb-8                   616MB/s ± 1%
-    EncodeSimpleSetAll/zeropb-8                   800MB/s ± 0%
+    EncodeSimpleSetAll/zeropb-8                     119ns ± 1%
 
     name                                         allocs/op
     EncodeSimpleSetAll/pb-8                          2.00 ± 0%
@@ -318,41 +290,26 @@ setting a field on a go struct.
     name                                         time/op
     EncodeSimpleSetRepeatedly/pb-8                  264ns ± 2%
     EncodeSimpleSetRepeatedly/gogopb-8              188ns ± 1%
-    EncodeSimpleSetRepeatedly/zeropb-8              366ns ± 0%
-
-    name                                         speed
-    EncodeSimpleSetRepeatedly/pb-8                409MB/s ± 2%
-    EncodeSimpleSetRepeatedly/gogopb-8            571MB/s ± 1%
-    EncodeSimpleSetRepeatedly/zeropb-8            294MB/s ± 0%
+    EncodeSimpleSetRepeatedly/zeropb-8              350ns ± 2%
 
     name                                         allocs/op
     EncodeSimpleSetRepeatedly/pb-8                   4.00 ± 0%
     EncodeSimpleSetRepeatedly/gogopb-8               2.00 ± 0%
     EncodeSimpleSetRepeatedly/zeropb-8               0.00
 
-Encoding a complex message is currently slower than other libraries. This is
-expected to get faster, but I haven't yet done speed of light measurements to
-see exactly how much faster.
-
-This benchmark currently causes allocations because the resulting encoded
-message is large enough that it triggers one of the conditions described in the
-Compromises section, but this is not intrinsic. These allocations will go away
-when we specialize FastIntMap.
+Encoding a complex message is also faster, though the ergonomics of this are
+currently not very good. There's some headroom to make it better, but it will
+never be as easy as the other libraries.
 
     name                                         time/op
     EncodeComplex/pb-8                             1.06µs ± 0%
     EncodeComplex/gogopb-8                          754ns ± 5%
-    EncodeComplex/zeropb-8                         1.34µs ± 1%
-
-    name                                         speed
-    EncodeComplex/pb-8                            420MB/s ± 0%
-    EncodeComplex/gogopb-8                        610MB/s ± 5%
-    EncodeComplex/zeropb-8                        325MB/s ± 1%
+    EncodeComplex/zeropb-8                          661ns ± 0%
 
     name                                         allocs/op
     EncodeComplex/pb-8                               7.00 ± 0%
     EncodeComplex/gogopb-8                           3.00 ± 0%
-    EncodeComplex/zeropb-8                           2.00 ± 0%
+    EncodeComplex/zeropb-8                           0.00
 
 
 [Protocol Buffer]: https://developers.google.com/protocol-buffers/

--- a/bench_test.go
+++ b/bench_test.go
@@ -73,266 +73,302 @@ func byteSum(b []byte) uint64 {
 func BenchmarkDecodeSimpleAccessNone(b *testing.B) {
 	buf := testEntryEncoded(b)
 
-	var pb raftpb.Entry
-	b.Run(`pb`, func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			if err := proto.Unmarshal(buf, &pb); err != nil {
-				b.Fatal(err)
+	{
+		var pb raftpb.Entry
+		b.Run(`pb`, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				if err := proto.Unmarshal(buf, &pb); err != nil {
+					b.Fatal(err)
+				}
 			}
-		}
-		b.SetBytes(int64(len(buf)))
-	})
+			b.SetBytes(int64(len(buf)))
+		})
+	}
 
-	var gogopb raftgogopb.Entry
-	b.Run(`gogopb`, func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			if err := proto.Unmarshal(buf, &gogopb); err != nil {
-				b.Fatal(err)
+	{
+		var gogopb raftgogopb.Entry
+		b.Run(`gogopb`, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				if err := proto.Unmarshal(buf, &gogopb); err != nil {
+					b.Fatal(err)
+				}
 			}
-		}
-		b.SetBytes(int64(len(buf)))
-	})
+			b.SetBytes(int64(len(buf)))
+		})
+	}
 
-	var zeropb raftzeropb.Entry
-	b.Run(`zeropb`, func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			if err := zeropb.Decode(buf); err != nil {
-				b.Fatal(err)
+	{
+		var zeropb raftzeropb.Entry
+		b.Run(`zeropb`, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				if err := zeropb.Decode(buf); err != nil {
+					b.Fatal(err)
+				}
 			}
-		}
-		b.SetBytes(int64(len(buf)))
-	})
+			b.SetBytes(int64(len(buf)))
+		})
+	}
 }
 
 func BenchmarkDecodeSimpleAccessAll(b *testing.B) {
 	buf := testEntryEncoded(b)
 
-	var pb raftpb.Entry
-	b.Run(`pb`, func(b *testing.B) {
-		var x uint64
-		for i := 0; i < b.N; i++ {
-			if err := proto.Unmarshal(buf, &pb); err != nil {
-				b.Fatal(err)
+	{
+		var pb raftpb.Entry
+		b.Run(`pb`, func(b *testing.B) {
+			var x uint64
+			for i := 0; i < b.N; i++ {
+				if err := proto.Unmarshal(buf, &pb); err != nil {
+					b.Fatal(err)
+				}
+				x += pb.GetTerm() + pb.GetIndex() + uint64(pb.GetType()) + byteSum(pb.GetData())
 			}
-			x += pb.GetTerm() + pb.GetIndex() + uint64(pb.GetType()) + byteSum(pb.GetData())
-		}
-		b.SetBytes(int64(len(buf)))
-	})
+			b.SetBytes(int64(len(buf)))
+		})
+	}
 
-	var gogopb raftgogopb.Entry
-	b.Run(`gogopb`, func(b *testing.B) {
-		var x uint64
-		for i := 0; i < b.N; i++ {
-			if err := proto.Unmarshal(buf, &gogopb); err != nil {
-				b.Fatal(err)
+	{
+		var gogopb raftgogopb.Entry
+		b.Run(`gogopb`, func(b *testing.B) {
+			var x uint64
+			for i := 0; i < b.N; i++ {
+				if err := proto.Unmarshal(buf, &gogopb); err != nil {
+					b.Fatal(err)
+				}
+				x += gogopb.Term + gogopb.Index + uint64(gogopb.Type) + byteSum(gogopb.Data)
 			}
-			x += gogopb.Term + gogopb.Index + uint64(gogopb.Type) + byteSum(pb.Data)
-		}
-		b.SetBytes(int64(len(buf)))
-	})
+			b.SetBytes(int64(len(buf)))
+		})
+	}
 
-	var zeropb raftzeropb.Entry
-	b.Run(`zeropb`, func(b *testing.B) {
-		var x uint64
-		for i := 0; i < b.N; i++ {
-			if err := zeropb.Decode(buf); err != nil {
-				b.Fatal(err)
+	{
+		var zeropb raftzeropb.Entry
+		b.Run(`zeropb`, func(b *testing.B) {
+			var x uint64
+			for i := 0; i < b.N; i++ {
+				if err := zeropb.Decode(buf); err != nil {
+					b.Fatal(err)
+				}
+				x += zeropb.Term() + zeropb.Index() + uint64(zeropb.Type()) + byteSum(zeropb.Data())
 			}
-			x += zeropb.Term() + zeropb.Index() + uint64(zeropb.Type()) + byteSum(zeropb.Data())
-		}
-		b.SetBytes(int64(len(buf)))
-	})
+			b.SetBytes(int64(len(buf)))
+		})
+	}
 }
 
 func BenchmarkDecodeSimpleAccessRepeatedly(b *testing.B) {
 	const numAccessRepetitions = 3
 	buf := testEntryEncoded(b)
 
-	var pb raftpb.Entry
-	b.Run(`pb`, func(b *testing.B) {
-		var x uint64
-		for i := 0; i < b.N; i++ {
-			if err := proto.Unmarshal(buf, &pb); err != nil {
-				b.Fatal(err)
+	{
+		var pb raftpb.Entry
+		b.Run(`pb`, func(b *testing.B) {
+			var x uint64
+			for i := 0; i < b.N; i++ {
+				if err := proto.Unmarshal(buf, &pb); err != nil {
+					b.Fatal(err)
+				}
+				for i := 0; i < numAccessRepetitions; i++ {
+					x += pb.GetTerm() + pb.GetIndex() + uint64(pb.GetType()) + byteSum(pb.GetData())
+				}
 			}
-			for i := 0; i < numAccessRepetitions; i++ {
-				x += pb.GetTerm() + pb.GetIndex() + uint64(pb.GetType()) + byteSum(pb.GetData())
-			}
-		}
-		b.SetBytes(int64(len(buf)))
-	})
+			b.SetBytes(int64(len(buf)))
+		})
+	}
 
-	var gogopb raftgogopb.Entry
-	b.Run(`gogopb`, func(b *testing.B) {
-		var x uint64
-		for i := 0; i < b.N; i++ {
-			if err := proto.Unmarshal(buf, &gogopb); err != nil {
-				b.Fatal(err)
+	{
+		var gogopb raftgogopb.Entry
+		b.Run(`gogopb`, func(b *testing.B) {
+			var x uint64
+			for i := 0; i < b.N; i++ {
+				if err := proto.Unmarshal(buf, &gogopb); err != nil {
+					b.Fatal(err)
+				}
+				for i := 0; i < numAccessRepetitions; i++ {
+					x += gogopb.Term + gogopb.Index + uint64(gogopb.Type) + byteSum(gogopb.Data)
+				}
 			}
-			for i := 0; i < numAccessRepetitions; i++ {
-				x += gogopb.Term + gogopb.Index + uint64(gogopb.Type) + byteSum(pb.Data)
-			}
-		}
-		b.SetBytes(int64(len(buf)))
-	})
+			b.SetBytes(int64(len(buf)))
+		})
+	}
 
-	var zeropb raftzeropb.Entry
-	b.Run(`zeropb`, func(b *testing.B) {
-		var x uint64
-		for i := 0; i < b.N; i++ {
-			if err := zeropb.Decode(buf); err != nil {
-				b.Fatal(err)
+	{
+		var zeropb raftzeropb.Entry
+		b.Run(`zeropb`, func(b *testing.B) {
+			var x uint64
+			for i := 0; i < b.N; i++ {
+				if err := zeropb.Decode(buf); err != nil {
+					b.Fatal(err)
+				}
+				for i := 0; i < numAccessRepetitions; i++ {
+					x += zeropb.Term() + zeropb.Index() + uint64(zeropb.Type()) + byteSum(zeropb.Data())
+				}
 			}
-			for i := 0; i < numAccessRepetitions; i++ {
-				x += zeropb.Term() + zeropb.Index() + uint64(zeropb.Type()) + byteSum(zeropb.Data())
-			}
-		}
-		b.SetBytes(int64(len(buf)))
-	})
+			b.SetBytes(int64(len(buf)))
+		})
+	}
 }
 
 func BenchmarkDecodeComplexAccessOne(b *testing.B) {
 	buf := testMessageEncoded(b, 3)
 
-	var pb raftpb.Message
-	b.Run(`pb`, func(b *testing.B) {
-		var x uint64
-		for i := 0; i < b.N; i++ {
-			if err := proto.Unmarshal(buf, &pb); err != nil {
-				b.Fatal(err)
+	{
+		var pb raftpb.Message
+		b.Run(`pb`, func(b *testing.B) {
+			var x uint64
+			for i := 0; i < b.N; i++ {
+				if err := proto.Unmarshal(buf, &pb); err != nil {
+					b.Fatal(err)
+				}
+				x += pb.GetTo()
 			}
-			x += pb.GetTo()
-		}
-		b.SetBytes(int64(len(buf)))
-	})
+			b.SetBytes(int64(len(buf)))
+		})
+	}
 
-	var gogopb raftgogopb.Message
-	b.Run(`gogopb`, func(b *testing.B) {
-		var x uint64
-		for i := 0; i < b.N; i++ {
-			if err := proto.Unmarshal(buf, &gogopb); err != nil {
-				b.Fatal(err)
+	{
+		var gogopb raftgogopb.Message
+		b.Run(`gogopb`, func(b *testing.B) {
+			var x uint64
+			for i := 0; i < b.N; i++ {
+				if err := proto.Unmarshal(buf, &gogopb); err != nil {
+					b.Fatal(err)
+				}
+				x += gogopb.To
 			}
-			x += gogopb.To
-		}
-		b.SetBytes(int64(len(buf)))
-	})
+			b.SetBytes(int64(len(buf)))
+		})
+	}
 
-	var zeropb raftzeropb.Message
-	b.Run(`zeropb`, func(b *testing.B) {
-		var x uint64
-		for i := 0; i < b.N; i++ {
-			if err := zeropb.Decode(buf); err != nil {
-				b.Fatal(err)
+	{
+		var zeropb raftzeropb.Message
+		b.Run(`zeropb`, func(b *testing.B) {
+			var x uint64
+			for i := 0; i < b.N; i++ {
+				if err := zeropb.Decode(buf); err != nil {
+					b.Fatal(err)
+				}
+				x += zeropb.To()
 			}
-			x += zeropb.To()
-		}
-		b.SetBytes(int64(len(buf)))
-	})
+			b.SetBytes(int64(len(buf)))
+		})
+	}
 }
 
 func BenchmarkDecodeComplexAccessRepeatedMessage(b *testing.B) {
 	buf := testMessageEncoded(b, 3)
 
-	var pb raftpb.Message
-	b.Run(`pb`, func(b *testing.B) {
-		var x uint64
-		for i := 0; i < b.N; i++ {
-			if err := proto.Unmarshal(buf, &pb); err != nil {
-				b.Fatal(err)
-			}
-			for _, e := range pb.GetEntries() {
-				if e == nil {
-					continue
-				}
-				x += e.GetTerm() + e.GetIndex() + uint64(e.GetType()) + byteSum(e.GetData())
-			}
-		}
-		b.SetBytes(int64(len(buf)))
-	})
-
-	var gogopb raftgogopb.Message
-	b.Run(`gogopb`, func(b *testing.B) {
-		var x uint64
-		for i := 0; i < b.N; i++ {
-			if err := proto.Unmarshal(buf, &gogopb); err != nil {
-				b.Fatal(err)
-			}
-			for _, e := range gogopb.Entries {
-				x += e.Term + e.Index + uint64(e.Type) + byteSum(e.Data)
-			}
-		}
-		b.SetBytes(int64(len(buf)))
-	})
-
-	var zeropb raftzeropb.Message
-	var zeropbE raftzeropb.Entry
-	b.Run(`zeropb`, func(b *testing.B) {
-		var x uint64
-		for i := 0; i < b.N; i++ {
-			if err := zeropb.Decode(buf); err != nil {
-				b.Fatal(err)
-			}
-			it := zeropb.Entries()
-			for {
-				if ok, err := it.Next(&zeropbE); !ok {
-					break
-				} else if err != nil {
+	{
+		var pb raftpb.Message
+		b.Run(`pb`, func(b *testing.B) {
+			var x uint64
+			for i := 0; i < b.N; i++ {
+				if err := proto.Unmarshal(buf, &pb); err != nil {
 					b.Fatal(err)
 				}
-				x += zeropbE.Term() + zeropbE.Index() + uint64(zeropbE.Type()) + byteSum(zeropbE.Data())
+				for _, e := range pb.GetEntries() {
+					if e == nil {
+						continue
+					}
+					x += e.GetTerm() + e.GetIndex() + uint64(e.GetType()) + byteSum(e.GetData())
+				}
 			}
-		}
-		b.SetBytes(int64(len(buf)))
-	})
+			b.SetBytes(int64(len(buf)))
+		})
+	}
+
+	{
+		var gogopb raftgogopb.Message
+		b.Run(`gogopb`, func(b *testing.B) {
+			var x uint64
+			for i := 0; i < b.N; i++ {
+				if err := proto.Unmarshal(buf, &gogopb); err != nil {
+					b.Fatal(err)
+				}
+				for _, e := range gogopb.Entries {
+					x += e.Term + e.Index + uint64(e.Type) + byteSum(e.Data)
+				}
+			}
+			b.SetBytes(int64(len(buf)))
+		})
+	}
+
+	{
+		var zeropb raftzeropb.Message
+		var zeropbE raftzeropb.Entry
+		b.Run(`zeropb`, func(b *testing.B) {
+			var x uint64
+			for i := 0; i < b.N; i++ {
+				if err := zeropb.Decode(buf); err != nil {
+					b.Fatal(err)
+				}
+				it := zeropb.Entries()
+				for {
+					if ok, err := it.Next(&zeropbE); !ok {
+						break
+					} else if err != nil {
+						b.Fatal(err)
+					}
+					x += zeropbE.Term() + zeropbE.Index() + uint64(zeropbE.Type()) + byteSum(zeropbE.Data())
+				}
+			}
+			b.SetBytes(int64(len(buf)))
+		})
+	}
 }
 
 func BenchmarkEncodeSimpleSetAll(b *testing.B) {
 	e := testEntry()
 
-	pbBuf := proto.NewBuffer(make([]byte, 0, 100+testByteArrayLen))
-	b.Run(`pb`, func(b *testing.B) {
-		var x int64
-		for i := 0; i < b.N; i++ {
-			pbBuf.Reset()
-			typ := raftpb.EntryType(e.Type)
-			pb := raftpb.Entry{Term: &e.Term, Index: &e.Index, Type: &typ, Data: e.Data}
-			if err := pbBuf.Marshal(&pb); err != nil {
-				b.Fatal(err)
+	{
+		pbBuf := proto.NewBuffer(make([]byte, 0, 100+testByteArrayLen))
+		b.Run(`pb`, func(b *testing.B) {
+			var x int64
+			for i := 0; i < b.N; i++ {
+				pbBuf.Reset()
+				typ := raftpb.EntryType(e.Type)
+				pb := raftpb.Entry{Term: &e.Term, Index: &e.Index, Type: &typ, Data: e.Data}
+				if err := pbBuf.Marshal(&pb); err != nil {
+					b.Fatal(err)
+				}
+				x += int64(len(pbBuf.Bytes()))
 			}
-			x += int64(len(pbBuf.Bytes()))
-		}
-		b.SetBytes(x / int64(b.N))
-	})
+			b.SetBytes(x / int64(b.N))
+		})
+	}
 
-	gogopbBuf := proto.NewBuffer(make([]byte, 0, 100+testByteArrayLen))
-	b.Run(`gogopb`, func(b *testing.B) {
-		var x int64
-		for i := 0; i < b.N; i++ {
-			gogopbBuf.Reset()
-			gogopb := raftgogopb.Entry{Term: e.Term, Index: e.Index, Type: e.Type, Data: e.Data}
-			if err := gogopbBuf.Marshal(&gogopb); err != nil {
-				b.Fatal(err)
+	{
+		gogopbBuf := proto.NewBuffer(make([]byte, 0, 100+testByteArrayLen))
+		b.Run(`gogopb`, func(b *testing.B) {
+			var x int64
+			for i := 0; i < b.N; i++ {
+				gogopbBuf.Reset()
+				gogopb := raftgogopb.Entry{Term: e.Term, Index: e.Index, Type: e.Type, Data: e.Data}
+				if err := gogopbBuf.Marshal(&gogopb); err != nil {
+					b.Fatal(err)
+				}
+				x += int64(len(gogopbBuf.Bytes()))
 			}
-			x += int64(len(gogopbBuf.Bytes()))
-		}
-		b.SetBytes(x / int64(b.N))
-	})
+			b.SetBytes(x / int64(b.N))
+		})
+	}
 
-	zeropbBuf := make([]byte, 0, 100+testByteArrayLen)
-	b.Run(`zeropb`, func(b *testing.B) {
-		var x int64
-		for i := 0; i < b.N; i++ {
-			var zeropb raftzeropb.Entry
-			zeropb.Reset(zeropbBuf)
-			zeropb.SetIndex(e.Index)
-			zeropb.SetTerm(e.Term)
-			zeropb.SetType(uint32(e.Type))
-			zeropb.SetData(e.Data)
-			x += int64(len(zeropb.Encode()))
-		}
-		b.SetBytes(x / int64(b.N))
-	})
+	{
+		zeropbBuf := make([]byte, 0, 100+testByteArrayLen)
+		b.Run(`zeropb`, func(b *testing.B) {
+			var x int64
+			for i := 0; i < b.N; i++ {
+				var zeropb raftzeropb.Entry
+				zeropb.Reset(zeropbBuf)
+				zeropb.SetIndex(e.Index)
+				zeropb.SetTerm(e.Term)
+				zeropb.SetType(uint32(e.Type))
+				zeropb.SetData(e.Data)
+				x += int64(len(zeropb.Encode()))
+			}
+			b.SetBytes(x / int64(b.N))
+		})
+	}
 }
 
 func BenchmarkEncodeSimpleSetRepeatedly(b *testing.B) {
@@ -340,57 +376,63 @@ func BenchmarkEncodeSimpleSetRepeatedly(b *testing.B) {
 	const bufLen = 100 + testByteArrayLen
 	e := testEntry()
 
-	pbBuf := proto.NewBuffer(make([]byte, 0, bufLen))
-	b.Run(`pb`, func(b *testing.B) {
-		var x int64
-		for i := 0; i < b.N; i++ {
-			pbBuf.Reset()
-			var pb raftpb.Entry
-			for j := 0; j < numSetRepetitions; j++ {
-				typ := raftpb.EntryType(e.Type)
-				pb = raftpb.Entry{Term: &e.Term, Index: &e.Index, Type: &typ, Data: e.Data}
+	{
+		pbBuf := proto.NewBuffer(make([]byte, 0, bufLen))
+		b.Run(`pb`, func(b *testing.B) {
+			var x int64
+			for i := 0; i < b.N; i++ {
+				pbBuf.Reset()
+				var pb raftpb.Entry
+				for j := 0; j < numSetRepetitions; j++ {
+					typ := raftpb.EntryType(e.Type)
+					pb = raftpb.Entry{Term: &e.Term, Index: &e.Index, Type: &typ, Data: e.Data}
+				}
+				if err := pbBuf.Marshal(&pb); err != nil {
+					b.Fatal(err)
+				}
+				x += int64(len(pbBuf.Bytes()))
 			}
-			if err := pbBuf.Marshal(&pb); err != nil {
-				b.Fatal(err)
-			}
-			x += int64(len(pbBuf.Bytes()))
-		}
-		b.SetBytes(x / int64(b.N))
-	})
+			b.SetBytes(x / int64(b.N))
+		})
+	}
 
-	gogopbBuf := proto.NewBuffer(make([]byte, 0, bufLen))
-	b.Run(`gogopb`, func(b *testing.B) {
-		var x int64
-		for i := 0; i < b.N; i++ {
-			gogopbBuf.Reset()
-			var gogopb raftgogopb.Entry
-			for j := 0; j < numSetRepetitions; j++ {
-				gogopb = raftgogopb.Entry{Term: e.Term, Index: e.Index, Type: e.Type, Data: e.Data}
+	{
+		gogopbBuf := proto.NewBuffer(make([]byte, 0, bufLen))
+		b.Run(`gogopb`, func(b *testing.B) {
+			var x int64
+			for i := 0; i < b.N; i++ {
+				gogopbBuf.Reset()
+				var gogopb raftgogopb.Entry
+				for j := 0; j < numSetRepetitions; j++ {
+					gogopb = raftgogopb.Entry{Term: e.Term, Index: e.Index, Type: e.Type, Data: e.Data}
+				}
+				if err := gogopbBuf.Marshal(&gogopb); err != nil {
+					b.Fatal(err)
+				}
+				x += int64(len(gogopbBuf.Bytes()))
 			}
-			if err := gogopbBuf.Marshal(&gogopb); err != nil {
-				b.Fatal(err)
-			}
-			x += int64(len(gogopbBuf.Bytes()))
-		}
-		b.SetBytes(x / int64(b.N))
-	})
+			b.SetBytes(x / int64(b.N))
+		})
+	}
 
-	zeropbBuf := make([]byte, 0, bufLen)
-	b.Run(`zeropb`, func(b *testing.B) {
-		var x int64
-		for i := 0; i < b.N; i++ {
-			var zeropb raftzeropb.Entry
-			zeropb.Reset(zeropbBuf)
-			for j := 0; j < numSetRepetitions; j++ {
-				zeropb.SetIndex(e.Index)
-				zeropb.SetTerm(e.Term)
-				zeropb.SetType(uint32(e.Type))
-				zeropb.SetData(e.Data)
+	{
+		zeropbBuf := make([]byte, 0, bufLen)
+		b.Run(`zeropb`, func(b *testing.B) {
+			var x int64
+			for i := 0; i < b.N; i++ {
+				var zeropb raftzeropb.Entry
+				zeropb.Reset(zeropbBuf)
+				for j := 0; j < numSetRepetitions; j++ {
+					zeropb.SetIndex(e.Index)
+					zeropb.SetTerm(e.Term)
+					zeropb.SetType(uint32(e.Type))
+					zeropb.SetData(e.Data)
+				}
+				x += int64(len(zeropb.Encode()))
 			}
-			x += int64(len(zeropb.Encode()))
-		}
-		b.SetBytes(x / int64(b.N))
-	})
+			b.SetBytes(x / int64(b.N))
+		})
+	}
 }
 
 func BenchmarkEncodeComplex(b *testing.B) {
@@ -398,101 +440,107 @@ func BenchmarkEncodeComplex(b *testing.B) {
 	const bufLen = 3 * (100 + testByteArrayLen)
 	m := testMessage(numEntries)
 
-	pbBuf := proto.NewBuffer(make([]byte, 0, bufLen))
-	b.Run(`pb`, func(b *testing.B) {
-		var x int64
-		for i := 0; i < b.N; i++ {
-			pbBuf.Reset()
+	{
+		pbBuf := proto.NewBuffer(make([]byte, 0, bufLen))
+		b.Run(`pb`, func(b *testing.B) {
+			var x int64
+			for i := 0; i < b.N; i++ {
+				pbBuf.Reset()
 
-			pb := &raftpb.Message{
-				To: &m.To, From: &m.From, Term: &m.Term, LogTerm: &m.LogTerm, Index: &m.Index,
-				Context: m.Context,
-				Snapshot: &raftpb.Snapshot{Metadata: &raftpb.SnapshotMetadata{
-					Index: &m.Snapshot.Metadata.Index, Term: &m.Snapshot.Metadata.Term,
-				}},
-				Entries: make([]*raftpb.Entry, len(m.Entries)),
-			}
-			for i := range m.Entries {
-				pb.Entries[i] = &raftpb.Entry{
-					Term: &m.Entries[i].Term, Index: &m.Entries[i].Index, Data: m.Entries[i].Data,
+				pb := &raftpb.Message{
+					To: &m.To, From: &m.From, Term: &m.Term, LogTerm: &m.LogTerm, Index: &m.Index,
+					Context: m.Context,
+					Snapshot: &raftpb.Snapshot{Metadata: &raftpb.SnapshotMetadata{
+						Index: &m.Snapshot.Metadata.Index, Term: &m.Snapshot.Metadata.Term,
+					}},
+					Entries: make([]*raftpb.Entry, len(m.Entries)),
 				}
-			}
-
-			if err := pbBuf.Marshal(pb); err != nil {
-				b.Fatal(err)
-			}
-			x += int64(len(pbBuf.Bytes()))
-		}
-		b.SetBytes(x / int64(b.N))
-	})
-
-	gogopbBuf := proto.NewBuffer(make([]byte, 0, bufLen))
-	b.Run(`gogopb`, func(b *testing.B) {
-		var x int64
-		for i := 0; i < b.N; i++ {
-			gogopbBuf.Reset()
-
-			gogopb := raftgogopb.Message{
-				To: m.To, From: m.From, Term: m.Term, LogTerm: m.LogTerm, Index: m.Index,
-				Context: m.Context,
-				Snapshot: raftgogopb.Snapshot{Metadata: raftgogopb.SnapshotMetadata{
-					Index: m.Snapshot.Metadata.Index, Term: m.Snapshot.Metadata.Term,
-				}},
-				Entries: make([]raftgogopb.Entry, len(m.Entries)),
-			}
-			for i := range m.Entries {
-				gogopb.Entries[i] = raftgogopb.Entry{
-					Term: m.Entries[i].Term, Index: m.Entries[i].Index, Data: m.Entries[i].Data,
+				for i := range m.Entries {
+					pb.Entries[i] = &raftpb.Entry{
+						Term: &m.Entries[i].Term, Index: &m.Entries[i].Index, Data: m.Entries[i].Data,
+					}
 				}
-			}
 
-			if err := gogopbBuf.Marshal(&gogopb); err != nil {
-				b.Fatal(err)
+				if err := pbBuf.Marshal(pb); err != nil {
+					b.Fatal(err)
+				}
+				x += int64(len(pbBuf.Bytes()))
 			}
-			x += int64(len(gogopbBuf.Bytes()))
-		}
-		b.SetBytes(x / int64(b.N))
-	})
-
-	// TODO(dan): Eeek. This is not ergonomic.
-	zeropbBufs := make([][]byte, 4)
-	for i := range zeropbBufs {
-		zeropbBufs[i] = make([]byte, 0, bufLen)
+			b.SetBytes(x / int64(b.N))
+		})
 	}
-	b.Run(`zeropb`, func(b *testing.B) {
-		var x int64
 
-		for i := 0; i < b.N; i++ {
-			var zeroM raftzeropb.Message
-			var zeroE raftzeropb.Entry
-			var zeroS raftzeropb.Snapshot
-			var zeroSM raftzeropb.SnapshotMetadata
+	{
+		gogopbBuf := proto.NewBuffer(make([]byte, 0, bufLen))
+		b.Run(`gogopb`, func(b *testing.B) {
+			var x int64
+			for i := 0; i < b.N; i++ {
+				gogopbBuf.Reset()
 
-			zeroM.Reset(zeropbBufs[0])
-			zeroM.SetTo(m.To)
-			zeroM.SetFrom(m.From)
-			zeroM.SetTerm(m.Term)
-			zeroM.SetLogTerm(m.LogTerm)
-			zeroM.SetIndex(m.Index)
-			zeroM.SetContext(m.Context)
+				gogopb := raftgogopb.Message{
+					To: m.To, From: m.From, Term: m.Term, LogTerm: m.LogTerm, Index: m.Index,
+					Context: m.Context,
+					Snapshot: raftgogopb.Snapshot{Metadata: raftgogopb.SnapshotMetadata{
+						Index: m.Snapshot.Metadata.Index, Term: m.Snapshot.Metadata.Term,
+					}},
+					Entries: make([]raftgogopb.Entry, len(m.Entries)),
+				}
+				for i := range m.Entries {
+					gogopb.Entries[i] = raftgogopb.Entry{
+						Term: m.Entries[i].Term, Index: m.Entries[i].Index, Data: m.Entries[i].Data,
+					}
+				}
 
-			zeroSM.Reset(zeropbBufs[1])
-			zeroSM.SetIndex(m.Snapshot.Metadata.Index)
-			zeroSM.SetTerm(m.Snapshot.Metadata.Term)
-
-			zeroS.Reset(zeropbBufs[2])
-			zeroS.SetMetadata(zeroSM)
-
-			for i := range m.Entries {
-				zeroE.Reset(zeropbBufs[3])
-				zeroE.SetTerm(m.Entries[i].Term)
-				zeroE.SetIndex(m.Entries[i].Index)
-				zeroE.SetData(m.Entries[i].Data)
-				zeroM.AppendToEntries(zeroE)
+				if err := gogopbBuf.Marshal(&gogopb); err != nil {
+					b.Fatal(err)
+				}
+				x += int64(len(gogopbBuf.Bytes()))
 			}
+			b.SetBytes(x / int64(b.N))
+		})
+	}
 
-			x += int64(len(zeroM.Encode()))
+	{
+		// TODO(dan): Eeek. This is not ergonomic.
+		zeropbBufs := make([][]byte, 4)
+		for i := range zeropbBufs {
+			zeropbBufs[i] = make([]byte, 0, bufLen)
 		}
-		b.SetBytes(x / int64(b.N))
-	})
+		b.Run(`zeropb`, func(b *testing.B) {
+			var x int64
+
+			for i := 0; i < b.N; i++ {
+				var zeroM raftzeropb.Message
+				var zeroE raftzeropb.Entry
+				var zeroS raftzeropb.Snapshot
+				var zeroSM raftzeropb.SnapshotMetadata
+
+				zeroM.Reset(zeropbBufs[0])
+				zeroM.SetTo(m.To)
+				zeroM.SetFrom(m.From)
+				zeroM.SetTerm(m.Term)
+				zeroM.SetLogTerm(m.LogTerm)
+				zeroM.SetIndex(m.Index)
+				zeroM.SetContext(m.Context)
+
+				zeroSM.Reset(zeropbBufs[1])
+				zeroSM.SetIndex(m.Snapshot.Metadata.Index)
+				zeroSM.SetTerm(m.Snapshot.Metadata.Term)
+
+				zeroS.Reset(zeropbBufs[2])
+				zeroS.SetMetadata(zeroSM)
+
+				for i := range m.Entries {
+					zeroE.Reset(zeropbBufs[3])
+					zeroE.SetTerm(m.Entries[i].Term)
+					zeroE.SetIndex(m.Entries[i].Index)
+					zeroE.SetData(m.Entries[i].Data)
+					zeroM.AppendToEntries(zeroE)
+				}
+
+				x += int64(len(zeroM.Encode()))
+			}
+			b.SetBytes(x / int64(b.N))
+		})
+	}
 }

--- a/golden/raftzeropb/raft.zeropb.go
+++ b/golden/raftzeropb/raft.zeropb.go
@@ -6,7 +6,7 @@ import "github.com/danhhz/zeropb"
 
 type Entry struct {
   buf []byte
-  offsets zeropb.FastIntMap
+  offsets [5]uint16
 }
 
 func (m *Entry) Encode() []byte {
@@ -15,7 +15,7 @@ func (m *Entry) Encode() []byte {
 
 func (m *Entry) Decode(buf []byte) error {
   m.buf = buf
-  return zeropb.Decode(m.buf, &m.offsets)
+  return zeropb.Decode(m.buf, m.offsets[:])
 }
 
 func (m *Entry) Reset(buf []byte) {
@@ -23,44 +23,46 @@ func (m *Entry) Reset(buf []byte) {
     panic(`buf must be empty`)
   }
   m.buf = buf
-  m.offsets.Clear()
+  for i := range m.offsets {
+    m.offsets[i] = 0
+  }
 }
 
 func (m *Entry) Term() uint64 {
-  return zeropb.GetUint64(m.buf, &m.offsets, 2)
+  return zeropb.GetUint64(m.buf, m.offsets[:], 2)
 }
 
 func (m *Entry) SetTerm(x uint64) {
-  zeropb.SetUint64(&m.buf, &m.offsets, 2, x)
+  zeropb.SetUint64(&m.buf, m.offsets[:], 2, x)
 }
 
 func (m *Entry) Index() uint64 {
-  return zeropb.GetUint64(m.buf, &m.offsets, 3)
+  return zeropb.GetUint64(m.buf, m.offsets[:], 3)
 }
 
 func (m *Entry) SetIndex(x uint64) {
-  zeropb.SetUint64(&m.buf, &m.offsets, 3, x)
+  zeropb.SetUint64(&m.buf, m.offsets[:], 3, x)
 }
 
 func (m *Entry) Type() uint32 {
-  return zeropb.GetUint32(m.buf, &m.offsets, 1)
+  return zeropb.GetUint32(m.buf, m.offsets[:], 1)
 }
 
 func (m *Entry) SetType(x uint32) {
-  zeropb.SetUint32(&m.buf, &m.offsets, 1, x)
+  zeropb.SetUint32(&m.buf, m.offsets[:], 1, x)
 }
 
 func (m *Entry) Data() []byte {
-  return zeropb.GetBytes(m.buf, &m.offsets, 4)
+  return zeropb.GetBytes(m.buf, m.offsets[:], 4)
 }
 
 func (m *Entry) SetData(x []byte) {
-  zeropb.SetBytes(&m.buf, &m.offsets, 4, x)
+  zeropb.SetBytes(&m.buf, m.offsets[:], 4, x)
 }
 
 type SnapshotMetadata struct {
   buf []byte
-  offsets zeropb.FastIntMap
+  offsets [4]uint16
 }
 
 func (m *SnapshotMetadata) Encode() []byte {
@@ -69,7 +71,7 @@ func (m *SnapshotMetadata) Encode() []byte {
 
 func (m *SnapshotMetadata) Decode(buf []byte) error {
   m.buf = buf
-  return zeropb.Decode(m.buf, &m.offsets)
+  return zeropb.Decode(m.buf, m.offsets[:])
 }
 
 func (m *SnapshotMetadata) Reset(buf []byte) {
@@ -77,11 +79,13 @@ func (m *SnapshotMetadata) Reset(buf []byte) {
     panic(`buf must be empty`)
   }
   m.buf = buf
-  m.offsets.Clear()
+  for i := range m.offsets {
+    m.offsets[i] = 0
+  }
 }
 
 func (m *SnapshotMetadata) ConfState(x *ConfState) (bool, error) {
-  buf := zeropb.GetBytes(m.buf, &m.offsets, 1)
+  buf := zeropb.GetBytes(m.buf, m.offsets[:], 1)
   if buf == nil {
     return false, nil
   }
@@ -90,28 +94,28 @@ func (m *SnapshotMetadata) ConfState(x *ConfState) (bool, error) {
 
 func (m *SnapshotMetadata) SetConfState(x ConfState) {
   buf := x.Encode()
-  zeropb.SetBytes(&m.buf, &m.offsets, 1, buf)
+  zeropb.SetBytes(&m.buf, m.offsets[:], 1, buf)
 }
 
 func (m *SnapshotMetadata) Index() uint64 {
-  return zeropb.GetUint64(m.buf, &m.offsets, 2)
+  return zeropb.GetUint64(m.buf, m.offsets[:], 2)
 }
 
 func (m *SnapshotMetadata) SetIndex(x uint64) {
-  zeropb.SetUint64(&m.buf, &m.offsets, 2, x)
+  zeropb.SetUint64(&m.buf, m.offsets[:], 2, x)
 }
 
 func (m *SnapshotMetadata) Term() uint64 {
-  return zeropb.GetUint64(m.buf, &m.offsets, 3)
+  return zeropb.GetUint64(m.buf, m.offsets[:], 3)
 }
 
 func (m *SnapshotMetadata) SetTerm(x uint64) {
-  zeropb.SetUint64(&m.buf, &m.offsets, 3, x)
+  zeropb.SetUint64(&m.buf, m.offsets[:], 3, x)
 }
 
 type Snapshot struct {
   buf []byte
-  offsets zeropb.FastIntMap
+  offsets [3]uint16
 }
 
 func (m *Snapshot) Encode() []byte {
@@ -120,7 +124,7 @@ func (m *Snapshot) Encode() []byte {
 
 func (m *Snapshot) Decode(buf []byte) error {
   m.buf = buf
-  return zeropb.Decode(m.buf, &m.offsets)
+  return zeropb.Decode(m.buf, m.offsets[:])
 }
 
 func (m *Snapshot) Reset(buf []byte) {
@@ -128,19 +132,21 @@ func (m *Snapshot) Reset(buf []byte) {
     panic(`buf must be empty`)
   }
   m.buf = buf
-  m.offsets.Clear()
+  for i := range m.offsets {
+    m.offsets[i] = 0
+  }
 }
 
 func (m *Snapshot) Data() []byte {
-  return zeropb.GetBytes(m.buf, &m.offsets, 1)
+  return zeropb.GetBytes(m.buf, m.offsets[:], 1)
 }
 
 func (m *Snapshot) SetData(x []byte) {
-  zeropb.SetBytes(&m.buf, &m.offsets, 1, x)
+  zeropb.SetBytes(&m.buf, m.offsets[:], 1, x)
 }
 
 func (m *Snapshot) Metadata(x *SnapshotMetadata) (bool, error) {
-  buf := zeropb.GetBytes(m.buf, &m.offsets, 2)
+  buf := zeropb.GetBytes(m.buf, m.offsets[:], 2)
   if buf == nil {
     return false, nil
   }
@@ -149,12 +155,12 @@ func (m *Snapshot) Metadata(x *SnapshotMetadata) (bool, error) {
 
 func (m *Snapshot) SetMetadata(x SnapshotMetadata) {
   buf := x.Encode()
-  zeropb.SetBytes(&m.buf, &m.offsets, 2, buf)
+  zeropb.SetBytes(&m.buf, m.offsets[:], 2, buf)
 }
 
 type Message struct {
   buf []byte
-  offsets zeropb.FastIntMap
+  offsets [13]uint16
 }
 
 func (m *Message) Encode() []byte {
@@ -163,7 +169,7 @@ func (m *Message) Encode() []byte {
 
 func (m *Message) Decode(buf []byte) error {
   m.buf = buf
-  return zeropb.Decode(m.buf, &m.offsets)
+  return zeropb.Decode(m.buf, m.offsets[:])
 }
 
 func (m *Message) Reset(buf []byte) {
@@ -171,55 +177,57 @@ func (m *Message) Reset(buf []byte) {
     panic(`buf must be empty`)
   }
   m.buf = buf
-  m.offsets.Clear()
+  for i := range m.offsets {
+    m.offsets[i] = 0
+  }
 }
 
 func (m *Message) Type() uint32 {
-  return zeropb.GetUint32(m.buf, &m.offsets, 1)
+  return zeropb.GetUint32(m.buf, m.offsets[:], 1)
 }
 
 func (m *Message) SetType(x uint32) {
-  zeropb.SetUint32(&m.buf, &m.offsets, 1, x)
+  zeropb.SetUint32(&m.buf, m.offsets[:], 1, x)
 }
 
 func (m *Message) To() uint64 {
-  return zeropb.GetUint64(m.buf, &m.offsets, 2)
+  return zeropb.GetUint64(m.buf, m.offsets[:], 2)
 }
 
 func (m *Message) SetTo(x uint64) {
-  zeropb.SetUint64(&m.buf, &m.offsets, 2, x)
+  zeropb.SetUint64(&m.buf, m.offsets[:], 2, x)
 }
 
 func (m *Message) From() uint64 {
-  return zeropb.GetUint64(m.buf, &m.offsets, 3)
+  return zeropb.GetUint64(m.buf, m.offsets[:], 3)
 }
 
 func (m *Message) SetFrom(x uint64) {
-  zeropb.SetUint64(&m.buf, &m.offsets, 3, x)
+  zeropb.SetUint64(&m.buf, m.offsets[:], 3, x)
 }
 
 func (m *Message) Term() uint64 {
-  return zeropb.GetUint64(m.buf, &m.offsets, 4)
+  return zeropb.GetUint64(m.buf, m.offsets[:], 4)
 }
 
 func (m *Message) SetTerm(x uint64) {
-  zeropb.SetUint64(&m.buf, &m.offsets, 4, x)
+  zeropb.SetUint64(&m.buf, m.offsets[:], 4, x)
 }
 
 func (m *Message) LogTerm() uint64 {
-  return zeropb.GetUint64(m.buf, &m.offsets, 5)
+  return zeropb.GetUint64(m.buf, m.offsets[:], 5)
 }
 
 func (m *Message) SetLogTerm(x uint64) {
-  zeropb.SetUint64(&m.buf, &m.offsets, 5, x)
+  zeropb.SetUint64(&m.buf, m.offsets[:], 5, x)
 }
 
 func (m *Message) Index() uint64 {
-  return zeropb.GetUint64(m.buf, &m.offsets, 6)
+  return zeropb.GetUint64(m.buf, m.offsets[:], 6)
 }
 
 func (m *Message) SetIndex(x uint64) {
-  zeropb.SetUint64(&m.buf, &m.offsets, 6, x)
+  zeropb.SetUint64(&m.buf, m.offsets[:], 6, x)
 }
 
 type MessageEntryIterator []byte
@@ -234,24 +242,24 @@ func (i *MessageEntryIterator) Next(m *Entry) (bool, error) {
 }
 
 func (m *Message) Entries() MessageEntryIterator {
-  return MessageEntryIterator(zeropb.GetRepeatedNonPacked(m.buf, &m.offsets, 7))
+  return MessageEntryIterator(zeropb.GetRepeatedNonPacked(m.buf, m.offsets[:], 7))
 }
 
 func (m *Message) AppendToEntries(x Entry) {
   buf := x.Encode()
-  zeropb.AppendBytes(&m.buf, &m.offsets, 7, buf)
+  zeropb.AppendBytes(&m.buf, m.offsets[:], 7, buf)
 }
 
 func (m *Message) Commit() uint64 {
-  return zeropb.GetUint64(m.buf, &m.offsets, 8)
+  return zeropb.GetUint64(m.buf, m.offsets[:], 8)
 }
 
 func (m *Message) SetCommit(x uint64) {
-  zeropb.SetUint64(&m.buf, &m.offsets, 8, x)
+  zeropb.SetUint64(&m.buf, m.offsets[:], 8, x)
 }
 
 func (m *Message) Snapshot(x *Snapshot) (bool, error) {
-  buf := zeropb.GetBytes(m.buf, &m.offsets, 9)
+  buf := zeropb.GetBytes(m.buf, m.offsets[:], 9)
   if buf == nil {
     return false, nil
   }
@@ -260,36 +268,36 @@ func (m *Message) Snapshot(x *Snapshot) (bool, error) {
 
 func (m *Message) SetSnapshot(x Snapshot) {
   buf := x.Encode()
-  zeropb.SetBytes(&m.buf, &m.offsets, 9, buf)
+  zeropb.SetBytes(&m.buf, m.offsets[:], 9, buf)
 }
 
 func (m *Message) Reject() bool {
-  return zeropb.GetBool(m.buf, &m.offsets, 10)
+  return zeropb.GetBool(m.buf, m.offsets[:], 10)
 }
 
 func (m *Message) SetReject(x bool) {
-  zeropb.SetBool(&m.buf, &m.offsets, 10, x)
+  zeropb.SetBool(&m.buf, m.offsets[:], 10, x)
 }
 
 func (m *Message) RejectHint() uint64 {
-  return zeropb.GetUint64(m.buf, &m.offsets, 11)
+  return zeropb.GetUint64(m.buf, m.offsets[:], 11)
 }
 
 func (m *Message) SetRejectHint(x uint64) {
-  zeropb.SetUint64(&m.buf, &m.offsets, 11, x)
+  zeropb.SetUint64(&m.buf, m.offsets[:], 11, x)
 }
 
 func (m *Message) Context() []byte {
-  return zeropb.GetBytes(m.buf, &m.offsets, 12)
+  return zeropb.GetBytes(m.buf, m.offsets[:], 12)
 }
 
 func (m *Message) SetContext(x []byte) {
-  zeropb.SetBytes(&m.buf, &m.offsets, 12, x)
+  zeropb.SetBytes(&m.buf, m.offsets[:], 12, x)
 }
 
 type HardState struct {
   buf []byte
-  offsets zeropb.FastIntMap
+  offsets [4]uint16
 }
 
 func (m *HardState) Encode() []byte {
@@ -298,7 +306,7 @@ func (m *HardState) Encode() []byte {
 
 func (m *HardState) Decode(buf []byte) error {
   m.buf = buf
-  return zeropb.Decode(m.buf, &m.offsets)
+  return zeropb.Decode(m.buf, m.offsets[:])
 }
 
 func (m *HardState) Reset(buf []byte) {
@@ -306,36 +314,38 @@ func (m *HardState) Reset(buf []byte) {
     panic(`buf must be empty`)
   }
   m.buf = buf
-  m.offsets.Clear()
+  for i := range m.offsets {
+    m.offsets[i] = 0
+  }
 }
 
 func (m *HardState) Term() uint64 {
-  return zeropb.GetUint64(m.buf, &m.offsets, 1)
+  return zeropb.GetUint64(m.buf, m.offsets[:], 1)
 }
 
 func (m *HardState) SetTerm(x uint64) {
-  zeropb.SetUint64(&m.buf, &m.offsets, 1, x)
+  zeropb.SetUint64(&m.buf, m.offsets[:], 1, x)
 }
 
 func (m *HardState) Vote() uint64 {
-  return zeropb.GetUint64(m.buf, &m.offsets, 2)
+  return zeropb.GetUint64(m.buf, m.offsets[:], 2)
 }
 
 func (m *HardState) SetVote(x uint64) {
-  zeropb.SetUint64(&m.buf, &m.offsets, 2, x)
+  zeropb.SetUint64(&m.buf, m.offsets[:], 2, x)
 }
 
 func (m *HardState) Commit() uint64 {
-  return zeropb.GetUint64(m.buf, &m.offsets, 3)
+  return zeropb.GetUint64(m.buf, m.offsets[:], 3)
 }
 
 func (m *HardState) SetCommit(x uint64) {
-  zeropb.SetUint64(&m.buf, &m.offsets, 3, x)
+  zeropb.SetUint64(&m.buf, m.offsets[:], 3, x)
 }
 
 type ConfState struct {
   buf []byte
-  offsets zeropb.FastIntMap
+  offsets [3]uint16
 }
 
 func (m *ConfState) Encode() []byte {
@@ -344,7 +354,7 @@ func (m *ConfState) Encode() []byte {
 
 func (m *ConfState) Decode(buf []byte) error {
   m.buf = buf
-  return zeropb.Decode(m.buf, &m.offsets)
+  return zeropb.Decode(m.buf, m.offsets[:])
 }
 
 func (m *ConfState) Reset(buf []byte) {
@@ -352,12 +362,14 @@ func (m *ConfState) Reset(buf []byte) {
     panic(`buf must be empty`)
   }
   m.buf = buf
-  m.offsets.Clear()
+  for i := range m.offsets {
+    m.offsets[i] = 0
+  }
 }
 
 type ConfChange struct {
   buf []byte
-  offsets zeropb.FastIntMap
+  offsets [5]uint16
 }
 
 func (m *ConfChange) Encode() []byte {
@@ -366,7 +378,7 @@ func (m *ConfChange) Encode() []byte {
 
 func (m *ConfChange) Decode(buf []byte) error {
   m.buf = buf
-  return zeropb.Decode(m.buf, &m.offsets)
+  return zeropb.Decode(m.buf, m.offsets[:])
 }
 
 func (m *ConfChange) Reset(buf []byte) {
@@ -374,38 +386,40 @@ func (m *ConfChange) Reset(buf []byte) {
     panic(`buf must be empty`)
   }
   m.buf = buf
-  m.offsets.Clear()
+  for i := range m.offsets {
+    m.offsets[i] = 0
+  }
 }
 
 func (m *ConfChange) ID() uint64 {
-  return zeropb.GetUint64(m.buf, &m.offsets, 1)
+  return zeropb.GetUint64(m.buf, m.offsets[:], 1)
 }
 
 func (m *ConfChange) SetID(x uint64) {
-  zeropb.SetUint64(&m.buf, &m.offsets, 1, x)
+  zeropb.SetUint64(&m.buf, m.offsets[:], 1, x)
 }
 
 func (m *ConfChange) Type() uint32 {
-  return zeropb.GetUint32(m.buf, &m.offsets, 2)
+  return zeropb.GetUint32(m.buf, m.offsets[:], 2)
 }
 
 func (m *ConfChange) SetType(x uint32) {
-  zeropb.SetUint32(&m.buf, &m.offsets, 2, x)
+  zeropb.SetUint32(&m.buf, m.offsets[:], 2, x)
 }
 
 func (m *ConfChange) NodeID() uint64 {
-  return zeropb.GetUint64(m.buf, &m.offsets, 3)
+  return zeropb.GetUint64(m.buf, m.offsets[:], 3)
 }
 
 func (m *ConfChange) SetNodeID(x uint64) {
-  zeropb.SetUint64(&m.buf, &m.offsets, 3, x)
+  zeropb.SetUint64(&m.buf, m.offsets[:], 3, x)
 }
 
 func (m *ConfChange) Context() []byte {
-  return zeropb.GetBytes(m.buf, &m.offsets, 4)
+  return zeropb.GetBytes(m.buf, m.offsets[:], 4)
 }
 
 func (m *ConfChange) SetContext(x []byte) {
-  zeropb.SetBytes(&m.buf, &m.offsets, 4, x)
+  zeropb.SetBytes(&m.buf, m.offsets[:], 4, x)
 }
 

--- a/golden/testzeropb/string.go
+++ b/golden/testzeropb/string.go
@@ -20,52 +20,52 @@ func (m TestMessage) Text() string {
 func (m TestMessage) WriteText(w io.Writer) {
 	// TODO(dan): A bunch of these aren't right, but this is currently only used
 	// while debugging test failures. Revisit if we start codegen'ing this.
-	if _, ok := m.offsets.Get(1); ok {
+	if offset := m.offsets[1]; offset != 0 {
 		fmt.Fprintf(w, `bool=%t `, m.Bool())
 	}
-	if _, ok := m.offsets.Get(2); ok {
+	if offset := m.offsets[2]; offset != 0 {
 		fmt.Fprintf(w, `int32=%d `, m.Int32())
 	}
-	if _, ok := m.offsets.Get(3); ok {
+	if offset := m.offsets[3]; offset != 0 {
 		fmt.Fprintf(w, `int64=%d `, m.Int64())
 	}
-	if _, ok := m.offsets.Get(4); ok {
+	if offset := m.offsets[4]; offset != 0 {
 		fmt.Fprintf(w, `uint32=%d `, m.Uint32())
 	}
-	if _, ok := m.offsets.Get(5); ok {
+	if offset := m.offsets[5]; offset != 0 {
 		fmt.Fprintf(w, `uint64=%d `, m.Uint64())
 	}
-	if _, ok := m.offsets.Get(6); ok {
+	if offset := m.offsets[6]; offset != 0 {
 		fmt.Fprintf(w, `sint32=%d `, m.Sint32())
 	}
-	if _, ok := m.offsets.Get(7); ok {
+	if offset := m.offsets[7]; offset != 0 {
 		fmt.Fprintf(w, `sint64=%d `, m.Sint64())
 	}
-	if _, ok := m.offsets.Get(8); ok {
+	if offset := m.offsets[8]; offset != 0 {
 		fmt.Fprintf(w, `fixed32=%d `, m.Fixed32())
 	}
-	if _, ok := m.offsets.Get(9); ok {
+	if offset := m.offsets[9]; offset != 0 {
 		fmt.Fprintf(w, `fixed64=%d `, m.Fixed64())
 	}
-	if _, ok := m.offsets.Get(10); ok {
+	if offset := m.offsets[10]; offset != 0 {
 		fmt.Fprintf(w, `sfixed32=%d `, m.Sfixed32())
 	}
-	if _, ok := m.offsets.Get(11); ok {
+	if offset := m.offsets[11]; offset != 0 {
 		fmt.Fprintf(w, `sfixed64=%d `, m.Sfixed64())
 	}
-	if _, ok := m.offsets.Get(12); ok {
+	if offset := m.offsets[12]; offset != 0 {
 		fmt.Fprintf(w, `double=%v `, m.Double())
 	}
-	if _, ok := m.offsets.Get(13); ok {
+	if offset := m.offsets[13]; offset != 0 {
 		fmt.Fprintf(w, `float=%v `, m.Float())
 	}
-	if _, ok := m.offsets.Get(14); ok {
+	if offset := m.offsets[14]; offset != 0 {
 		fmt.Fprintf(w, `string=%s `, m.String())
 	}
-	if _, ok := m.offsets.Get(15); ok {
+	if offset := m.offsets[15]; offset != 0 {
 		fmt.Fprintf(w, `byte_array=%s `, strconv.Quote(string(m.ByteArray())))
 	}
-	if _, ok := m.offsets.Get(16); ok {
+	if offset := m.offsets[16]; offset != 0 {
 		fmt.Fprintf(w, `enum=%d `, m.Enum())
 	}
 	var sub TestMessage

--- a/golden/testzeropb/test.zeropb.go
+++ b/golden/testzeropb/test.zeropb.go
@@ -6,7 +6,7 @@ import "github.com/danhhz/zeropb"
 
 type TestMessage struct {
   buf []byte
-  offsets zeropb.FastIntMap
+  offsets [35]uint16
 }
 
 func (m *TestMessage) Encode() []byte {
@@ -15,7 +15,7 @@ func (m *TestMessage) Encode() []byte {
 
 func (m *TestMessage) Decode(buf []byte) error {
   m.buf = buf
-  return zeropb.Decode(m.buf, &m.offsets)
+  return zeropb.Decode(m.buf, m.offsets[:])
 }
 
 func (m *TestMessage) Reset(buf []byte) {
@@ -23,139 +23,141 @@ func (m *TestMessage) Reset(buf []byte) {
     panic(`buf must be empty`)
   }
   m.buf = buf
-  m.offsets.Clear()
+  for i := range m.offsets {
+    m.offsets[i] = 0
+  }
 }
 
 func (m *TestMessage) Bool() bool {
-  return zeropb.GetBool(m.buf, &m.offsets, 1)
+  return zeropb.GetBool(m.buf, m.offsets[:], 1)
 }
 
 func (m *TestMessage) SetBool(x bool) {
-  zeropb.SetBool(&m.buf, &m.offsets, 1, x)
+  zeropb.SetBool(&m.buf, m.offsets[:], 1, x)
 }
 
 func (m *TestMessage) Int32() int32 {
-  return zeropb.GetInt32(m.buf, &m.offsets, 2)
+  return zeropb.GetInt32(m.buf, m.offsets[:], 2)
 }
 
 func (m *TestMessage) SetInt32(x int32) {
-  zeropb.SetInt32(&m.buf, &m.offsets, 2, x)
+  zeropb.SetInt32(&m.buf, m.offsets[:], 2, x)
 }
 
 func (m *TestMessage) Int64() int64 {
-  return zeropb.GetInt64(m.buf, &m.offsets, 3)
+  return zeropb.GetInt64(m.buf, m.offsets[:], 3)
 }
 
 func (m *TestMessage) SetInt64(x int64) {
-  zeropb.SetInt64(&m.buf, &m.offsets, 3, x)
+  zeropb.SetInt64(&m.buf, m.offsets[:], 3, x)
 }
 
 func (m *TestMessage) Uint32() uint32 {
-  return zeropb.GetUint32(m.buf, &m.offsets, 4)
+  return zeropb.GetUint32(m.buf, m.offsets[:], 4)
 }
 
 func (m *TestMessage) SetUint32(x uint32) {
-  zeropb.SetUint32(&m.buf, &m.offsets, 4, x)
+  zeropb.SetUint32(&m.buf, m.offsets[:], 4, x)
 }
 
 func (m *TestMessage) Uint64() uint64 {
-  return zeropb.GetUint64(m.buf, &m.offsets, 5)
+  return zeropb.GetUint64(m.buf, m.offsets[:], 5)
 }
 
 func (m *TestMessage) SetUint64(x uint64) {
-  zeropb.SetUint64(&m.buf, &m.offsets, 5, x)
+  zeropb.SetUint64(&m.buf, m.offsets[:], 5, x)
 }
 
 func (m *TestMessage) Sint32() int32 {
-  return zeropb.GetZigZagInt32(m.buf, &m.offsets, 6)
+  return zeropb.GetZigZagInt32(m.buf, m.offsets[:], 6)
 }
 
 func (m *TestMessage) SetSint32(x int32) {
-  zeropb.SetZigZagInt32(&m.buf, &m.offsets, 6, x)
+  zeropb.SetZigZagInt32(&m.buf, m.offsets[:], 6, x)
 }
 
 func (m *TestMessage) Sint64() int64 {
-  return zeropb.GetZigZagInt64(m.buf, &m.offsets, 7)
+  return zeropb.GetZigZagInt64(m.buf, m.offsets[:], 7)
 }
 
 func (m *TestMessage) SetSint64(x int64) {
-  zeropb.SetZigZagInt64(&m.buf, &m.offsets, 7, x)
+  zeropb.SetZigZagInt64(&m.buf, m.offsets[:], 7, x)
 }
 
 func (m *TestMessage) Fixed32() uint32 {
-  return zeropb.GetFixedUint32(m.buf, &m.offsets, 8)
+  return zeropb.GetFixedUint32(m.buf, m.offsets[:], 8)
 }
 
 func (m *TestMessage) SetFixed32(x uint32) {
-  zeropb.SetFixedUint32(&m.buf, &m.offsets, 8, x)
+  zeropb.SetFixedUint32(&m.buf, m.offsets[:], 8, x)
 }
 
 func (m *TestMessage) Fixed64() uint64 {
-  return zeropb.GetFixedUint64(m.buf, &m.offsets, 9)
+  return zeropb.GetFixedUint64(m.buf, m.offsets[:], 9)
 }
 
 func (m *TestMessage) SetFixed64(x uint64) {
-  zeropb.SetFixedUint64(&m.buf, &m.offsets, 9, x)
+  zeropb.SetFixedUint64(&m.buf, m.offsets[:], 9, x)
 }
 
 func (m *TestMessage) Sfixed32() int32 {
-  return zeropb.GetFixedInt32(m.buf, &m.offsets, 10)
+  return zeropb.GetFixedInt32(m.buf, m.offsets[:], 10)
 }
 
 func (m *TestMessage) SetSfixed32(x int32) {
-  zeropb.SetFixedInt32(&m.buf, &m.offsets, 10, x)
+  zeropb.SetFixedInt32(&m.buf, m.offsets[:], 10, x)
 }
 
 func (m *TestMessage) Sfixed64() int64 {
-  return zeropb.GetFixedInt64(m.buf, &m.offsets, 11)
+  return zeropb.GetFixedInt64(m.buf, m.offsets[:], 11)
 }
 
 func (m *TestMessage) SetSfixed64(x int64) {
-  zeropb.SetFixedInt64(&m.buf, &m.offsets, 11, x)
+  zeropb.SetFixedInt64(&m.buf, m.offsets[:], 11, x)
 }
 
 func (m *TestMessage) Double() float64 {
-  return zeropb.GetFloat64(m.buf, &m.offsets, 12)
+  return zeropb.GetFloat64(m.buf, m.offsets[:], 12)
 }
 
 func (m *TestMessage) SetDouble(x float64) {
-  zeropb.SetFloat64(&m.buf, &m.offsets, 12, x)
+  zeropb.SetFloat64(&m.buf, m.offsets[:], 12, x)
 }
 
 func (m *TestMessage) Float() float32 {
-  return zeropb.GetFloat32(m.buf, &m.offsets, 13)
+  return zeropb.GetFloat32(m.buf, m.offsets[:], 13)
 }
 
 func (m *TestMessage) SetFloat(x float32) {
-  zeropb.SetFloat32(&m.buf, &m.offsets, 13, x)
+  zeropb.SetFloat32(&m.buf, m.offsets[:], 13, x)
 }
 
 func (m *TestMessage) String() string {
-  return zeropb.GetString(m.buf, &m.offsets, 14)
+  return zeropb.GetString(m.buf, m.offsets[:], 14)
 }
 
 func (m *TestMessage) SetString(x string) {
-  zeropb.SetString(&m.buf, &m.offsets, 14, x)
+  zeropb.SetString(&m.buf, m.offsets[:], 14, x)
 }
 
 func (m *TestMessage) ByteArray() []byte {
-  return zeropb.GetBytes(m.buf, &m.offsets, 15)
+  return zeropb.GetBytes(m.buf, m.offsets[:], 15)
 }
 
 func (m *TestMessage) SetByteArray(x []byte) {
-  zeropb.SetBytes(&m.buf, &m.offsets, 15, x)
+  zeropb.SetBytes(&m.buf, m.offsets[:], 15, x)
 }
 
 func (m *TestMessage) Enum() uint32 {
-  return zeropb.GetUint32(m.buf, &m.offsets, 16)
+  return zeropb.GetUint32(m.buf, m.offsets[:], 16)
 }
 
 func (m *TestMessage) SetEnum(x uint32) {
-  zeropb.SetUint32(&m.buf, &m.offsets, 16, x)
+  zeropb.SetUint32(&m.buf, m.offsets[:], 16, x)
 }
 
 func (m *TestMessage) Message(x *TestMessage) (bool, error) {
-  buf := zeropb.GetBytes(m.buf, &m.offsets, 17)
+  buf := zeropb.GetBytes(m.buf, m.offsets[:], 17)
   if buf == nil {
     return false, nil
   }
@@ -164,7 +166,7 @@ func (m *TestMessage) Message(x *TestMessage) (bool, error) {
 
 func (m *TestMessage) SetMessage(x TestMessage) {
   buf := x.Encode()
-  zeropb.SetBytes(&m.buf, &m.offsets, 17, buf)
+  zeropb.SetBytes(&m.buf, m.offsets[:], 17, buf)
 }
 
 type TestMessageTestMessageIterator []byte
@@ -179,11 +181,11 @@ func (i *TestMessageTestMessageIterator) Next(m *TestMessage) (bool, error) {
 }
 
 func (m *TestMessage) Messages() TestMessageTestMessageIterator {
-  return TestMessageTestMessageIterator(zeropb.GetRepeatedNonPacked(m.buf, &m.offsets, 34))
+  return TestMessageTestMessageIterator(zeropb.GetRepeatedNonPacked(m.buf, m.offsets[:], 34))
 }
 
 func (m *TestMessage) AppendToMessages(x TestMessage) {
   buf := x.Encode()
-  zeropb.AppendBytes(&m.buf, &m.offsets, 34, buf)
+  zeropb.AppendBytes(&m.buf, m.offsets[:], 34, buf)
 }
 

--- a/zeropb.go
+++ b/zeropb.go
@@ -13,9 +13,9 @@ import (
 )
 
 // GetBool gets an encoded bool field with the given field id.
-func GetBool(buf []byte, offsets *FastIntMap, fieldID int) bool {
-	offset, ok := offsets.Get(fieldID)
-	if !ok {
+func GetBool(buf []byte, offsets []uint16, fieldID int) bool {
+	offset := int(offsets[fieldID])
+	if offset == 0 {
 		return false
 	}
 	x, _ := binary.Uvarint(buf[offset:])
@@ -23,9 +23,9 @@ func GetBool(buf []byte, offsets *FastIntMap, fieldID int) bool {
 }
 
 // GetInt32 gets an encoded int32 field with the given field id.
-func GetInt32(buf []byte, offsets *FastIntMap, fieldID int) int32 {
-	offset, ok := offsets.Get(fieldID)
-	if !ok {
+func GetInt32(buf []byte, offsets []uint16, fieldID int) int32 {
+	offset := int(offsets[fieldID])
+	if offset == 0 {
 		return 0
 	}
 	x, _ := binary.Uvarint(buf[offset:])
@@ -33,9 +33,9 @@ func GetInt32(buf []byte, offsets *FastIntMap, fieldID int) int32 {
 }
 
 // GetInt64 gets an encoded int64 field with the given field id.
-func GetInt64(buf []byte, offsets *FastIntMap, fieldID int) int64 {
-	offset, ok := offsets.Get(fieldID)
-	if !ok {
+func GetInt64(buf []byte, offsets []uint16, fieldID int) int64 {
+	offset := int(offsets[fieldID])
+	if offset == 0 {
 		return 0
 	}
 	x, _ := binary.Uvarint(buf[offset:])
@@ -43,9 +43,9 @@ func GetInt64(buf []byte, offsets *FastIntMap, fieldID int) int64 {
 }
 
 // GetUint32 gets an encoded uint32 field with the given field id.
-func GetUint32(buf []byte, offsets *FastIntMap, fieldID int) uint32 {
-	offset, ok := offsets.Get(fieldID)
-	if !ok {
+func GetUint32(buf []byte, offsets []uint16, fieldID int) uint32 {
+	offset := int(offsets[fieldID])
+	if offset == 0 {
 		return 0
 	}
 	x, _ := binary.Uvarint(buf[offset:])
@@ -53,9 +53,9 @@ func GetUint32(buf []byte, offsets *FastIntMap, fieldID int) uint32 {
 }
 
 // GetUint64 gets an encoded uint64 field with the given field id.
-func GetUint64(buf []byte, offsets *FastIntMap, fieldID int) uint64 {
-	offset, ok := offsets.Get(fieldID)
-	if !ok {
+func GetUint64(buf []byte, offsets []uint16, fieldID int) uint64 {
+	offset := int(offsets[fieldID])
+	if offset == 0 {
 		return 0
 	}
 	x, _ := binary.Uvarint(buf[offset:])
@@ -63,9 +63,9 @@ func GetUint64(buf []byte, offsets *FastIntMap, fieldID int) uint64 {
 }
 
 // GetZigZagInt32 gets a zig-zag encoded int32 field with the given field id.
-func GetZigZagInt32(buf []byte, offsets *FastIntMap, fieldID int) int32 {
-	offset, ok := offsets.Get(fieldID)
-	if !ok {
+func GetZigZagInt32(buf []byte, offsets []uint16, fieldID int) int32 {
+	offset := int(offsets[fieldID])
+	if offset == 0 {
 		return 0
 	}
 	x, _ := binary.Varint(buf[offset:])
@@ -73,9 +73,9 @@ func GetZigZagInt32(buf []byte, offsets *FastIntMap, fieldID int) int32 {
 }
 
 // GetZigZagInt64 gets a zig-zag encoded int64 field with the given field id.
-func GetZigZagInt64(buf []byte, offsets *FastIntMap, fieldID int) int64 {
-	offset, ok := offsets.Get(fieldID)
-	if !ok {
+func GetZigZagInt64(buf []byte, offsets []uint16, fieldID int) int64 {
+	offset := int(offsets[fieldID])
+	if offset == 0 {
 		return 0
 	}
 	x, _ := binary.Varint(buf[offset:])
@@ -84,9 +84,9 @@ func GetZigZagInt64(buf []byte, offsets *FastIntMap, fieldID int) int64 {
 
 // GetFixedUint32 gets a little-endian encoded uint32 field with the given field
 // id.
-func GetFixedUint32(buf []byte, offsets *FastIntMap, fieldID int) uint32 {
-	offset, ok := offsets.Get(fieldID)
-	if !ok {
+func GetFixedUint32(buf []byte, offsets []uint16, fieldID int) uint32 {
+	offset := int(offsets[fieldID])
+	if offset == 0 {
 		return 0
 	}
 	return binary.LittleEndian.Uint32(buf[offset : offset+4])
@@ -94,9 +94,9 @@ func GetFixedUint32(buf []byte, offsets *FastIntMap, fieldID int) uint32 {
 
 // GetFixedUint64 gets a little-endian encoded uint64 field with the given field
 // id.
-func GetFixedUint64(buf []byte, offsets *FastIntMap, fieldID int) uint64 {
-	offset, ok := offsets.Get(fieldID)
-	if !ok {
+func GetFixedUint64(buf []byte, offsets []uint16, fieldID int) uint64 {
+	offset := int(offsets[fieldID])
+	if offset == 0 {
 		return 0
 	}
 	return binary.LittleEndian.Uint64(buf[offset : offset+8])
@@ -104,9 +104,9 @@ func GetFixedUint64(buf []byte, offsets *FastIntMap, fieldID int) uint64 {
 
 // GetFixedInt32 gets a little-endian encoded int32 field with the given field
 // id.
-func GetFixedInt32(buf []byte, offsets *FastIntMap, fieldID int) int32 {
-	offset, ok := offsets.Get(fieldID)
-	if !ok {
+func GetFixedInt32(buf []byte, offsets []uint16, fieldID int) int32 {
+	offset := int(offsets[fieldID])
+	if offset == 0 {
 		return 0
 	}
 	return int32(binary.LittleEndian.Uint32(buf[offset : offset+4]))
@@ -114,9 +114,9 @@ func GetFixedInt32(buf []byte, offsets *FastIntMap, fieldID int) int32 {
 
 // GetFixedInt64 gets a little-endian encoded int64 field with the given field
 // id.
-func GetFixedInt64(buf []byte, offsets *FastIntMap, fieldID int) int64 {
-	offset, ok := offsets.Get(fieldID)
-	if !ok {
+func GetFixedInt64(buf []byte, offsets []uint16, fieldID int) int64 {
+	offset := int(offsets[fieldID])
+	if offset == 0 {
 		return 0
 	}
 	return int64(binary.LittleEndian.Uint64(buf[offset : offset+8]))
@@ -124,9 +124,9 @@ func GetFixedInt64(buf []byte, offsets *FastIntMap, fieldID int) int64 {
 
 // GetFloat32 gets a little-endian, IEEE 754 encoded float32 field with the
 // given field id.
-func GetFloat32(buf []byte, offsets *FastIntMap, fieldID int) float32 {
-	offset, ok := offsets.Get(fieldID)
-	if !ok {
+func GetFloat32(buf []byte, offsets []uint16, fieldID int) float32 {
+	offset := int(offsets[fieldID])
+	if offset == 0 {
 		return 0
 	}
 	bits := binary.LittleEndian.Uint32(buf[offset : offset+4])
@@ -135,9 +135,9 @@ func GetFloat32(buf []byte, offsets *FastIntMap, fieldID int) float32 {
 
 // GetFloat64 gets a little-endian, IEEE 754 encoded float64 field with the
 // given field id.
-func GetFloat64(buf []byte, offsets *FastIntMap, fieldID int) float64 {
-	offset, ok := offsets.Get(fieldID)
-	if !ok {
+func GetFloat64(buf []byte, offsets []uint16, fieldID int) float64 {
+	offset := int(offsets[fieldID])
+	if offset == 0 {
 		return 0
 	}
 	bits := binary.LittleEndian.Uint64(buf[offset : offset+8])
@@ -145,9 +145,9 @@ func GetFloat64(buf []byte, offsets *FastIntMap, fieldID int) float64 {
 }
 
 // GetString gets an encoded string field with the given field id.
-func GetString(buf []byte, offsets *FastIntMap, fieldID int) string {
-	offset, ok := offsets.Get(fieldID)
-	if !ok {
+func GetString(buf []byte, offsets []uint16, fieldID int) string {
+	offset := int(offsets[fieldID])
+	if offset == 0 {
 		return ``
 	}
 	len, lenSize := binary.Uvarint(buf[offset:])
@@ -157,9 +157,9 @@ func GetString(buf []byte, offsets *FastIntMap, fieldID int) string {
 }
 
 // GetBytes gets an encoded []byte field with the given field id.
-func GetBytes(buf []byte, offsets *FastIntMap, fieldID int) []byte {
-	offset, ok := offsets.Get(fieldID)
-	if !ok {
+func GetBytes(buf []byte, offsets []uint16, fieldID int) []byte {
+	offset := int(offsets[fieldID])
+	if offset == 0 {
 		return nil
 	}
 	len, lenSize := binary.Uvarint(buf[offset:])
@@ -169,7 +169,7 @@ func GetBytes(buf []byte, offsets *FastIntMap, fieldID int) []byte {
 
 // SetBool set an encoded bool field with the given field id, overwriting an
 // old value if present.
-func SetBool(buf *[]byte, offsets *FastIntMap, fieldID int, x bool) {
+func SetBool(buf *[]byte, offsets []uint16, fieldID int, x bool) {
 	var scratch [1]byte
 	if x {
 		scratch[0] = 1
@@ -180,7 +180,7 @@ func SetBool(buf *[]byte, offsets *FastIntMap, fieldID int, x bool) {
 
 // SetInt32 set an encoded int32 field with the given field id, overwriting an
 // old value if present.
-func SetInt32(buf *[]byte, offsets *FastIntMap, fieldID int, x int32) {
+func SetInt32(buf *[]byte, offsets []uint16, fieldID int, x int32) {
 	// WIP huh? var scratch [binary.MaxVarintLen32]byte
 	var scratch [binary.MaxVarintLen64]byte
 	n := binary.PutUvarint(scratch[:], uint64(x))
@@ -190,7 +190,7 @@ func SetInt32(buf *[]byte, offsets *FastIntMap, fieldID int, x int32) {
 
 // SetInt64 set an encoded int64 field with the given field id, overwriting an
 // old value if present.
-func SetInt64(buf *[]byte, offsets *FastIntMap, fieldID int, x int64) {
+func SetInt64(buf *[]byte, offsets []uint16, fieldID int, x int64) {
 	var scratch [binary.MaxVarintLen64]byte
 	n := binary.PutUvarint(scratch[:], uint64(x))
 	var valLen, val []byte = nil, scratch[:n]
@@ -199,7 +199,7 @@ func SetInt64(buf *[]byte, offsets *FastIntMap, fieldID int, x int64) {
 
 // SetUint32 set an encoded uint64 field with the given field id, overwriting an
 // old value if present.
-func SetUint32(buf *[]byte, offsets *FastIntMap, fieldID int, x uint32) {
+func SetUint32(buf *[]byte, offsets []uint16, fieldID int, x uint32) {
 	var scratch [binary.MaxVarintLen32]byte
 	n := binary.PutUvarint(scratch[:], uint64(x))
 	var valLen, val []byte = nil, scratch[:n]
@@ -208,7 +208,7 @@ func SetUint32(buf *[]byte, offsets *FastIntMap, fieldID int, x uint32) {
 
 // SetUint64 set an encoded uint64 field with the given field id, overwriting an
 // old value if present.
-func SetUint64(buf *[]byte, offsets *FastIntMap, fieldID int, x uint64) {
+func SetUint64(buf *[]byte, offsets []uint16, fieldID int, x uint64) {
 	var scratch [binary.MaxVarintLen64]byte
 	n := binary.PutUvarint(scratch[:], x)
 	var valLen, val []byte = nil, scratch[:n]
@@ -217,7 +217,7 @@ func SetUint64(buf *[]byte, offsets *FastIntMap, fieldID int, x uint64) {
 
 // SetZigZagInt32 set a zig-zag encoded int64 field with the given field id,
 // overwriting an old value if present.
-func SetZigZagInt32(buf *[]byte, offsets *FastIntMap, fieldID int, x int32) {
+func SetZigZagInt32(buf *[]byte, offsets []uint16, fieldID int, x int32) {
 	var scratch [binary.MaxVarintLen32]byte
 	n := binary.PutVarint(scratch[:], int64(x))
 	var valLen, val []byte = nil, scratch[:n]
@@ -226,7 +226,7 @@ func SetZigZagInt32(buf *[]byte, offsets *FastIntMap, fieldID int, x int32) {
 
 // SetZigZagInt64 set a zig-zag encoded int64 field with the given field id,
 // overwriting an old value if present.
-func SetZigZagInt64(buf *[]byte, offsets *FastIntMap, fieldID int, x int64) {
+func SetZigZagInt64(buf *[]byte, offsets []uint16, fieldID int, x int64) {
 	var scratch [binary.MaxVarintLen64]byte
 	n := binary.PutVarint(scratch[:], x)
 	var valLen, val []byte = nil, scratch[:n]
@@ -235,7 +235,7 @@ func SetZigZagInt64(buf *[]byte, offsets *FastIntMap, fieldID int, x int64) {
 
 // SetFixedUint32 set a little-endian encoded uint32 field with the given field
 // id, overwriting an old value if present.
-func SetFixedUint32(buf *[]byte, offsets *FastIntMap, fieldID int, x uint32) {
+func SetFixedUint32(buf *[]byte, offsets []uint16, fieldID int, x uint32) {
 	var scratch [4]byte
 	binary.LittleEndian.PutUint32(scratch[:], x)
 	var valLen, val []byte = nil, scratch[:]
@@ -244,7 +244,7 @@ func SetFixedUint32(buf *[]byte, offsets *FastIntMap, fieldID int, x uint32) {
 
 // SetFixedUint64 set a little-endian encoded uint64 field with the given field
 // id, overwriting an old value if present.
-func SetFixedUint64(buf *[]byte, offsets *FastIntMap, fieldID int, x uint64) {
+func SetFixedUint64(buf *[]byte, offsets []uint16, fieldID int, x uint64) {
 	var scratch [8]byte
 	binary.LittleEndian.PutUint64(scratch[:], x)
 	var valLen, val []byte = nil, scratch[:]
@@ -253,7 +253,7 @@ func SetFixedUint64(buf *[]byte, offsets *FastIntMap, fieldID int, x uint64) {
 
 // SetFixedInt32 set a little-endian encoded int32 field with the given field
 // id, overwriting an old value if present.
-func SetFixedInt32(buf *[]byte, offsets *FastIntMap, fieldID int, x int32) {
+func SetFixedInt32(buf *[]byte, offsets []uint16, fieldID int, x int32) {
 	var scratch [4]byte
 	binary.LittleEndian.PutUint32(scratch[:], uint32(x))
 	var valLen, val []byte = nil, scratch[:]
@@ -262,7 +262,7 @@ func SetFixedInt32(buf *[]byte, offsets *FastIntMap, fieldID int, x int32) {
 
 // SetFixedInt64 set a little-endian encoded int64 field with the given field
 // id, overwriting an old value if present.
-func SetFixedInt64(buf *[]byte, offsets *FastIntMap, fieldID int, x int64) {
+func SetFixedInt64(buf *[]byte, offsets []uint16, fieldID int, x int64) {
 	var scratch [8]byte
 	binary.LittleEndian.PutUint64(scratch[:], uint64(x))
 	var valLen, val []byte = nil, scratch[:]
@@ -271,7 +271,7 @@ func SetFixedInt64(buf *[]byte, offsets *FastIntMap, fieldID int, x int64) {
 
 // SetFloat32 set a little-endian, IEEE 754 encoded float32 field with the given
 // field id, overwriting an old value if present.
-func SetFloat32(buf *[]byte, offsets *FastIntMap, fieldID int, x float32) {
+func SetFloat32(buf *[]byte, offsets []uint16, fieldID int, x float32) {
 	var scratch [4]byte
 	bits := math.Float32bits(x)
 	binary.LittleEndian.PutUint32(scratch[:], bits)
@@ -281,7 +281,7 @@ func SetFloat32(buf *[]byte, offsets *FastIntMap, fieldID int, x float32) {
 
 // SetFloat64 set a little-endian, IEEE 754 encoded float64 field with the given
 // field id, overwriting an old value if present.
-func SetFloat64(buf *[]byte, offsets *FastIntMap, fieldID int, x float64) {
+func SetFloat64(buf *[]byte, offsets []uint16, fieldID int, x float64) {
 	var scratch [8]byte
 	bits := math.Float64bits(x)
 	binary.LittleEndian.PutUint64(scratch[:], bits)
@@ -291,7 +291,7 @@ func SetFloat64(buf *[]byte, offsets *FastIntMap, fieldID int, x float64) {
 
 // SetString set an encoded string field with the given field id, overwriting an
 // old value if present.
-func SetString(buf *[]byte, offsets *FastIntMap, fieldID int, x string) {
+func SetString(buf *[]byte, offsets []uint16, fieldID int, x string) {
 	var scratch [binary.MaxVarintLen64]byte
 	hdr := *(*reflect.StringHeader)(unsafe.Pointer(&x))
 	data := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
@@ -306,7 +306,7 @@ func SetString(buf *[]byte, offsets *FastIntMap, fieldID int, x string) {
 
 // SetBytes set an encoded []byte field with the given field id, overwriting an
 // old value if present.
-func SetBytes(buf *[]byte, offsets *FastIntMap, fieldID int, x []byte) {
+func SetBytes(buf *[]byte, offsets []uint16, fieldID int, x []byte) {
 	var scratch [binary.MaxVarintLen64]byte
 	n := binary.PutUvarint(scratch[:], uint64(len(x)))
 	var valLen, val []byte = scratch[:n], x
@@ -315,14 +315,14 @@ func SetBytes(buf *[]byte, offsets *FastIntMap, fieldID int, x []byte) {
 
 // AppendBytes appends one value to an encoded []byte field with the given field
 // id.
-func AppendBytes(buf *[]byte, offsets *FastIntMap, fieldID int, x []byte) {
+func AppendBytes(buf *[]byte, offsets []uint16, fieldID int, x []byte) {
 	var scratch [binary.MaxVarintLen64]byte
 	n := binary.PutUvarint(scratch[:], uint64(len(x)))
 	var valLen, val []byte = scratch[:n], x
 	appendSingle(buf, offsets, fieldID, proto.WireBytes, valLen, val)
 }
 
-func setSingle(buf *[]byte, offsets *FastIntMap, fieldID, typ int, valLen, val []byte) {
+func setSingle(buf *[]byte, offsets []uint16, fieldID, typ int, valLen, val []byte) {
 	// TODO(dan): We could save space if we didn't encode fields set to the
 	// default value.
 
@@ -330,7 +330,7 @@ func setSingle(buf *[]byte, offsets *FastIntMap, fieldID, typ int, valLen, val [
 	tag := uint64(fieldID<<3 | typ)
 	tagLen := binary.PutUvarint(scratch[:], tag)
 
-	if offset, ok := offsets.Get(fieldID); ok {
+	if offset := int(offsets[fieldID]); offset != 0 {
 		var oldLen int
 		switch typ {
 		case proto.WireVarint:
@@ -357,25 +357,22 @@ func setSingle(buf *[]byte, offsets *FastIntMap, fieldID, typ int, valLen, val [
 		(*buf) = (*buf)[:len(*buf)-removedBytes]
 
 		// Adjust every offset in the map that's larger than fieldEnd down by
-		// removedBytes. In general, setting a FastIntMap while iterating it is bad
-		// news, but we happen to know that setting a smaller (still positive) value
-		// for an entry already in the map will not cause it to flap from small to
-		// large. This is still a little scary though.
-		offsets.ForEach(func(fieldID int, offset int) {
-			if offset > fieldEnd {
-				offsets.Set(fieldID, offset-removedBytes)
+		// removedBytes.
+		for i, offset := range offsets {
+			if int(offset) > fieldEnd {
+				offsets[i] -= uint16(removedBytes)
 			}
-		})
+		}
 	}
 	*buf = append(*buf, scratch[:tagLen]...)
 
 	offset := len(*buf)
-	offsets.Set(fieldID, offset)
+	offsets[fieldID] = uint16(offset)
 	*buf = append(*buf, valLen...)
 	*buf = append(*buf, val...)
 }
 
-func appendSingle(buf *[]byte, offsets *FastIntMap, fieldID, typ int, valLen, val []byte) {
+func appendSingle(buf *[]byte, offsets []uint16, fieldID, typ int, valLen, val []byte) {
 	var scratch [binary.MaxVarintLen64]byte
 
 	tag := uint64(fieldID<<3 | typ)
@@ -384,8 +381,8 @@ func appendSingle(buf *[]byte, offsets *FastIntMap, fieldID, typ int, valLen, va
 
 	offset := len(*buf)
 	// The offset for repeated fields always points at the first one.
-	if _, ok := offsets.Get(fieldID); !ok {
-		offsets.Set(fieldID, offset)
+	if existing := int(offsets[fieldID]); existing != 0 {
+		offsets[fieldID] = uint16(offset)
 	}
 	*buf = append(*buf, valLen...)
 	*buf = append(*buf, val...)
@@ -395,9 +392,9 @@ func appendSingle(buf *[]byte, offsets *FastIntMap, fieldID, typ int, valLen, va
 // first instance of a non-packed repeated field and with everything after it.
 // It's positioned past the tag of the field, so the very first thing will be a
 // varint length. This is exactly the input expected by FindNextField.
-func GetRepeatedNonPacked(buf []byte, offsets *FastIntMap, fieldID int) []byte {
-	offset, ok := offsets.Get(fieldID)
-	if !ok {
+func GetRepeatedNonPacked(buf []byte, offsets []uint16, fieldID int) []byte {
+	offset := int(offsets[fieldID])
+	if offset == 0 {
 		return nil
 	}
 	return buf[offset:]
@@ -405,8 +402,13 @@ func GetRepeatedNonPacked(buf []byte, offsets *FastIntMap, fieldID int) []byte {
 
 // Decode parses and validates a proto message, filling in a map of field id ->
 // offset as it goes.
-func Decode(buf []byte, offsets *FastIntMap) error {
-	offsets.Clear()
+func Decode(buf []byte, offsets []uint16) error {
+	if len(buf) > math.MaxUint16 {
+		return errors.Errorf(`cannot decode messages longer than %d bytes`, math.MaxUint16)
+	}
+	for i := range offsets {
+		offsets[i] = 0
+	}
 	for idx := 0; idx < len(buf); {
 		tag, size := binary.Uvarint(buf[idx:])
 		idx += size
@@ -415,21 +417,21 @@ func Decode(buf []byte, offsets *FastIntMap) error {
 		// fmt.Printf("tag=%x field=%x typ=%x\n", tag, field, typ)
 		switch typ {
 		case proto.WireVarint:
-			offsets.Set(field, idx)
+			offsets[field] = uint16(idx)
 			_, size := binary.Uvarint(buf[idx:])
 			idx += size
 		case proto.WireFixed32:
-			offsets.Set(field, idx)
+			offsets[field] = uint16(idx)
 			idx += 4
 		case proto.WireFixed64:
-			offsets.Set(field, idx)
+			offsets[field] = uint16(idx)
 			idx += 8
 		case proto.WireBytes:
 			// Set the offset if this is the first one we've found but don't overwrite
 			// an earlier offset. The repeated message iterator will start from this
 			// offset and re-parse the rest of the message to find the rest of them.
-			if _, ok := offsets.Get(field); !ok {
-				offsets.Set(field, idx)
+			if existing := offsets[field]; existing == 0 {
+				offsets[field] = uint16(idx)
 			}
 			// TODO(dan): The proto spec specifically allows a single message
 			// to be split, but I don't understand why it would happen. It's


### PR DESCRIPTION
FastIntMap is great, but we can do better by specializing the offsets
map at code generating time. For now, switch everything to an array of
`[MaxFieldID+1]uint16` which should be the speed of light for absolute
fastest thing we could do. This also guarantees zero allocations for
every operation (excepting only field `Set`s on a message with an under
allocated buffer).

This is terrible for messages with sparse fields, and there are some
ideas in #6 for a second offset map implementation for those messages
and heuristics for when to use which map. This will be fixed by v1, but
in the meantime zeropb will be an exceptionally bad fit for messages
with sparse field ids.

Touches #6.

    name                                         old time/op    new time/op    delta
    DecodeSimpleAccessNone/pb-8                     181ns ± 1%     183ns ± 1%      ~     (p=0.079 n=5+5)
    DecodeSimpleAccessNone/gogopb-8                 106ns ± 0%     108ns ± 1%    +1.51%  (p=0.016 n=4+5)
    DecodeSimpleAccessNone/zeropb-8                72.1ns ± 3%    50.4ns ± 3%   -30.16%  (p=0.008 n=5+5)
    DecodeSimpleAccessAll/pb-8                      235ns ± 1%     234ns ± 0%      ~     (p=0.095 n=5+4)
    DecodeSimpleAccessAll/gogopb-8                  155ns ± 1%     156ns ± 1%      ~     (p=0.103 n=5+5)
    DecodeSimpleAccessAll/zeropb-8                  166ns ± 0%     132ns ± 0%   -20.48%  (p=0.029 n=4+4)
    DecodeSimpleAccessRepeatedly/pb-8               356ns ± 1%     348ns ± 2%    -2.19%  (p=0.024 n=5+5)
    DecodeSimpleAccessRepeatedly/gogopb-8           267ns ± 1%     283ns ±25%      ~     (p=0.690 n=5+5)
    DecodeSimpleAccessRepeatedly/zeropb-8           362ns ± 1%     305ns ± 1%   -15.81%  (p=0.016 n=5+4)
    DecodeComplexAccessOne/pb-8                    1.70µs ± 1%    1.77µs ± 9%    +4.38%  (p=0.008 n=5+5)
    DecodeComplexAccessOne/gogopb-8                 848ns ± 1%     854ns ± 0%    +0.64%  (p=0.048 n=5+5)
    DecodeComplexAccessOne/zeropb-8                 478ns ± 0%     167ns ± 0%   -65.09%  (p=0.016 n=5+4)
    DecodeComplexAccessRepeatedMessage/pb-8        1.89µs ± 0%    1.89µs ± 0%      ~     (p=0.114 n=4+4)
    DecodeComplexAccessRepeatedMessage/gogopb-8    1.03µs ± 0%    1.03µs ± 0%      ~     (p=0.167 n=5+5)
    DecodeComplexAccessRepeatedMessage/zeropb-8    1.24µs ± 3%    0.72µs ± 1%   -42.22%  (p=0.008 n=5+5)
    EncodeSimpleSetAll/pb-8                         232ns ± 2%     220ns ± 3%    -4.84%  (p=0.008 n=5+5)
    EncodeSimpleSetAll/gogopb-8                     182ns ± 1%     183ns ± 2%      ~     (p=0.317 n=5+5)
    EncodeSimpleSetAll/zeropb-8                     139ns ± 0%     119ns ± 1%   -14.39%  (p=0.016 n=4+5)
    EncodeSimpleSetRepeatedly/pb-8                  283ns ± 2%     272ns ± 1%    -3.89%  (p=0.008 n=5+5)
    EncodeSimpleSetRepeatedly/gogopb-8              196ns ± 1%     196ns ± 0%      ~     (p=0.683 n=5+5)
    EncodeSimpleSetRepeatedly/zeropb-8              378ns ± 0%     350ns ± 2%    -7.35%  (p=0.016 n=4+5)
    EncodeComplex/pb-8                             1.10µs ± 1%    1.11µs ± 2%      ~     (p=0.881 n=5+5)
    EncodeComplex/gogopb-8                          761ns ± 0%     764ns ± 0%    +0.47%  (p=0.024 n=5+5)
    EncodeComplex/zeropb-8                         1.38µs ± 1%    0.66µs ± 0%   -52.19%  (p=0.016 n=5+4)

    name                                         old speed      new speed      delta
    DecodeSimpleAccessNone/pb-8                   594MB/s ± 1%   588MB/s ± 1%      ~     (p=0.095 n=5+5)
    DecodeSimpleAccessNone/gogopb-8              1.02GB/s ± 0%  1.00GB/s ± 0%    -1.70%  (p=0.008 n=5+5)
    DecodeSimpleAccessNone/zeropb-8              1.50GB/s ± 3%  2.14GB/s ± 3%   +43.21%  (p=0.008 n=5+5)
    DecodeSimpleAccessAll/pb-8                    459MB/s ± 1%   460MB/s ± 1%      ~     (p=0.421 n=5+5)
    DecodeSimpleAccessAll/gogopb-8                695MB/s ± 1%   690MB/s ± 0%    -0.80%  (p=0.016 n=5+5)
    DecodeSimpleAccessAll/zeropb-8                648MB/s ± 0%   814MB/s ± 0%   +25.59%  (p=0.008 n=5+5)
    DecodeSimpleAccessRepeatedly/pb-8             303MB/s ± 1%   310MB/s ± 2%    +2.27%  (p=0.008 n=5+5)
    DecodeSimpleAccessRepeatedly/gogopb-8         404MB/s ± 1%   387MB/s ±21%      ~     (p=0.690 n=5+5)
    DecodeSimpleAccessRepeatedly/zeropb-8         298MB/s ± 1%   354MB/s ± 1%   +18.88%  (p=0.016 n=5+4)
    DecodeComplexAccessOne/pb-8                   271MB/s ± 1%   260MB/s ± 8%    -4.01%  (p=0.008 n=5+5)
    DecodeComplexAccessOne/gogopb-8               542MB/s ± 1%   538MB/s ± 0%      ~     (p=0.056 n=5+5)
    DecodeComplexAccessOne/zeropb-8               960MB/s ± 0%  2743MB/s ± 0%  +185.66%  (p=0.008 n=5+5)
    DecodeComplexAccessRepeatedMessage/pb-8       244MB/s ± 0%   244MB/s ± 0%      ~     (p=0.114 n=4+4)
    DecodeComplexAccessRepeatedMessage/gogopb-8   445MB/s ± 0%   446MB/s ± 0%      ~     (p=0.310 n=5+5)
    DecodeComplexAccessRepeatedMessage/zeropb-8   370MB/s ± 3%   640MB/s ± 1%   +73.03%  (p=0.008 n=5+5)
    EncodeSimpleSetAll/pb-8                       466MB/s ± 2%   489MB/s ± 3%    +4.99%  (p=0.008 n=5+5)
    EncodeSimpleSetAll/gogopb-8                   592MB/s ± 1%   589MB/s ± 1%      ~     (p=0.421 n=5+5)
    EncodeSimpleSetAll/zeropb-8                   776MB/s ± 1%   903MB/s ± 1%   +16.40%  (p=0.008 n=5+5)
    EncodeSimpleSetRepeatedly/pb-8                381MB/s ± 2%   397MB/s ± 1%    +4.06%  (p=0.008 n=5+5)
    EncodeSimpleSetRepeatedly/gogopb-8            550MB/s ± 1%   551MB/s ± 0%      ~     (p=0.794 n=5+5)
    EncodeSimpleSetRepeatedly/zeropb-8            286MB/s ± 0%   308MB/s ± 2%    +7.86%  (p=0.016 n=4+5)
    EncodeComplex/pb-8                            404MB/s ± 1%   401MB/s ± 2%      ~     (p=0.841 n=5+5)
    EncodeComplex/gogopb-8                        604MB/s ± 0%   601MB/s ± 0%    -0.47%  (p=0.016 n=5+5)
    EncodeComplex/zeropb-8                        315MB/s ± 1%   659MB/s ± 0%  +109.08%  (p=0.008 n=5+5)

    name                                         old alloc/op   new alloc/op   delta
    DecodeSimpleAccessNone/pb-8                      136B ± 0%      136B ± 0%      ~     (all equal)
    DecodeSimpleAccessNone/gogopb-8                  112B ± 0%      112B ± 0%      ~     (all equal)
    DecodeSimpleAccessNone/zeropb-8                 0.00B          0.00B           ~     (all equal)
    DecodeSimpleAccessAll/pb-8                       136B ± 0%      136B ± 0%      ~     (all equal)
    DecodeSimpleAccessAll/gogopb-8                   112B ± 0%      112B ± 0%      ~     (all equal)
    DecodeSimpleAccessAll/zeropb-8                  0.00B          0.00B           ~     (all equal)
    DecodeSimpleAccessRepeatedly/pb-8                136B ± 0%      136B ± 0%      ~     (all equal)
    DecodeSimpleAccessRepeatedly/gogopb-8            112B ± 0%      112B ± 0%      ~     (all equal)
    DecodeSimpleAccessRepeatedly/zeropb-8           0.00B          0.00B           ~     (all equal)
    DecodeComplexAccessOne/pb-8                    1.11kB ± 0%    1.11kB ± 0%      ~     (all equal)
    DecodeComplexAccessOne/gogopb-8                  960B ± 0%      960B ± 0%      ~     (all equal)
    DecodeComplexAccessOne/zeropb-8                 0.00B          0.00B           ~     (all equal)
    DecodeComplexAccessRepeatedMessage/pb-8        1.11kB ± 0%    1.11kB ± 0%      ~     (all equal)
    DecodeComplexAccessRepeatedMessage/gogopb-8      960B ± 0%      960B ± 0%      ~     (all equal)
    DecodeComplexAccessRepeatedMessage/zeropb-8     0.00B          0.00B           ~     (all equal)
    EncodeSimpleSetAll/pb-8                         84.0B ± 0%     84.0B ± 0%      ~     (all equal)
    EncodeSimpleSetAll/gogopb-8                      192B ± 0%      192B ± 0%      ~     (all equal)
    EncodeSimpleSetAll/zeropb-8                     0.00B          0.00B           ~     (all equal)
    EncodeSimpleSetRepeatedly/pb-8                  92.0B ± 0%     92.0B ± 0%      ~     (all equal)
    EncodeSimpleSetRepeatedly/gogopb-8               192B ± 0%      192B ± 0%      ~     (all equal)
    EncodeSimpleSetRepeatedly/zeropb-8              0.00B          0.00B           ~     (all equal)
    EncodeComplex/pb-8                               560B ± 0%      560B ± 0%      ~     (all equal)
    EncodeComplex/gogopb-8                         1.02kB ± 0%    1.02kB ± 0%      ~     (all equal)
    EncodeComplex/zeropb-8                         1.20kB ± 0%    0.00kB       -100.00%  (p=0.008 n=5+5)

    name                                         old allocs/op  new allocs/op  delta
    DecodeSimpleAccessNone/pb-8                      4.00 ± 0%      4.00 ± 0%      ~     (all equal)
    DecodeSimpleAccessNone/gogopb-8                  1.00 ± 0%      1.00 ± 0%      ~     (all equal)
    DecodeSimpleAccessNone/zeropb-8                  0.00           0.00           ~     (all equal)
    DecodeSimpleAccessAll/pb-8                       4.00 ± 0%      4.00 ± 0%      ~     (all equal)
    DecodeSimpleAccessAll/gogopb-8                   1.00 ± 0%      1.00 ± 0%      ~     (all equal)
    DecodeSimpleAccessAll/zeropb-8                   0.00           0.00           ~     (all equal)
    DecodeSimpleAccessRepeatedly/pb-8                4.00 ± 0%      4.00 ± 0%      ~     (all equal)
    DecodeSimpleAccessRepeatedly/gogopb-8            1.00 ± 0%      1.00 ± 0%      ~     (all equal)
    DecodeSimpleAccessRepeatedly/zeropb-8            0.00           0.00           ~     (all equal)
    DecodeComplexAccessOne/pb-8                      33.0 ± 0%      33.0 ± 0%      ~     (all equal)
    DecodeComplexAccessOne/gogopb-8                  7.00 ± 0%      7.00 ± 0%      ~     (all equal)
    DecodeComplexAccessOne/zeropb-8                  0.00           0.00           ~     (all equal)
    DecodeComplexAccessRepeatedMessage/pb-8          33.0 ± 0%      33.0 ± 0%      ~     (all equal)
    DecodeComplexAccessRepeatedMessage/gogopb-8      7.00 ± 0%      7.00 ± 0%      ~     (all equal)
    DecodeComplexAccessRepeatedMessage/zeropb-8      0.00           0.00           ~     (all equal)
    EncodeSimpleSetAll/pb-8                          2.00 ± 0%      2.00 ± 0%      ~     (all equal)
    EncodeSimpleSetAll/gogopb-8                      2.00 ± 0%      2.00 ± 0%      ~     (all equal)
    EncodeSimpleSetAll/zeropb-8                      0.00           0.00           ~     (all equal)
    EncodeSimpleSetRepeatedly/pb-8                   4.00 ± 0%      4.00 ± 0%      ~     (all equal)
    EncodeSimpleSetRepeatedly/gogopb-8               2.00 ± 0%      2.00 ± 0%      ~     (all equal)
    EncodeSimpleSetRepeatedly/zeropb-8               0.00           0.00           ~     (all equal)
    EncodeComplex/pb-8                               7.00 ± 0%      7.00 ± 0%      ~     (all equal)
    EncodeComplex/gogopb-8                           3.00 ± 0%      3.00 ± 0%      ~     (all equal)
    EncodeComplex/zeropb-8                           2.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)